### PR TITLE
Add legislative evolution tracker

### DIFF
--- a/pspcz_analyzer/config.py
+++ b/pspcz_analyzer/config.py
@@ -73,6 +73,16 @@ TISKY_META_DIR = "tisky_meta"
 PSP_TISKT_URL_TEMPLATE = "https://www.psp.cz/sqw/text/tiskt.sqw?o={period}&ct={ct}&ct1=0"
 PSP_HISTORIE_URL_TEMPLATE = "https://www.psp.cz/sqw/historie.sqw?o={period}&t={ct}"
 TISKY_HISTORIE_DIR = "tisky_historie"
+
+# Legislative evolution: law changes, related bills, sub-tisk versions
+PSP_LAW_CHANGES_URL_TEMPLATE = "https://www.psp.cz/sqw/historie.sqw?o={period}&t={ct}&snzp=1"
+PSP_RELATED_BILLS_URL_TEMPLATE = "https://www.psp.cz/sqw/tisky.sqw?idsb={idsb}"
+PSP_SUBTISKT_URL_TEMPLATE = (
+    "https://www.psp.cz/sqw/text/tiskt.sqw?O={period}&CT={ct}&CT1={ct1}"
+)
+TISKY_LAW_CHANGES_DIR = "tisky_law_changes"
+TISKY_RELATED_BILLS_DIR = "related_bills"
+TISKY_VERSION_DIFFS_DIR = "tisky_version_diffs"
 PSP_ORIG2_BASE_URL = "https://www.psp.cz/sqw/text/orig2.sqw"
 PSP_REQUEST_DELAY = 1.0  # seconds between requests to psp.cz
 

--- a/pspcz_analyzer/data/history_scraper.py
+++ b/pspcz_analyzer/data/history_scraper.py
@@ -82,6 +82,7 @@ class TiskHistory:
     current_status: str = "projednáváno"
     law_number: str | None = None
     scraped_at: str = ""
+    law_changes: list[dict] = field(default_factory=list)
 
 
 def _extract_first_date(text: str) -> str | None:
@@ -316,6 +317,7 @@ def history_from_dict(d: dict) -> TiskHistory:
         current_status=d.get("current_status", "projednáváno"),
         law_number=d.get("law_number"),
         scraped_at=d.get("scraped_at", ""),
+        law_changes=d.get("law_changes", []),
     )
 
 

--- a/pspcz_analyzer/data/law_changes_scraper.py
+++ b/pspcz_analyzer/data/law_changes_scraper.py
@@ -1,0 +1,265 @@
+"""Scraper for proposed law changes and related bills from psp.cz.
+
+Parses:
+- ``historie.sqw?snzp=1`` — which existing laws a bill proposes to modify
+- ``tisky.sqw?idsb=...`` — all other bills modifying the same laws
+"""
+
+import json
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import httpx
+from bs4 import BeautifulSoup
+from loguru import logger
+
+from pspcz_analyzer.config import (
+    PSP_LAW_CHANGES_URL_TEMPLATE,
+    PSP_RELATED_BILLS_URL_TEMPLATE,
+    PSP_REQUEST_DELAY,
+    TISKY_LAW_CHANGES_DIR,
+    TISKY_META_DIR,
+    TISKY_RELATED_BILLS_DIR,
+)
+
+# Regex to extract idsb parameter from tisky.sqw links
+_IDSB_RE = re.compile(r"idsb=(\d+)", re.IGNORECASE)
+# Regex to extract period and ct from historie.sqw links
+_HISTORIE_LINK_RE = re.compile(r"historie\.sqw\?o=(\d+)&t=(\d+)", re.IGNORECASE)
+
+
+@dataclass
+class ProposedLawChange:
+    """A single proposed change to an existing law."""
+
+    citace: str = ""  # law citation (e.g. "zákon č. 89/2012 Sb.")
+    zmena: str = ""  # type of change (e.g. "mění", "ruší")
+    predpis: str = ""  # law name / description
+    od_ct: int | None = None  # sub-tisk number where change is introduced
+    idsb: int | None = None  # link to related bills page
+
+
+@dataclass
+class RelatedBill:
+    """A bill found via the related-bills page (tisky.sqw?idsb=...)."""
+
+    cislo: str = ""  # tisk number as displayed
+    kratky_nazev: str = ""  # short title
+    typ_tisku: str = ""  # print type
+    stav: str = ""  # current status
+    period: int | None = None  # electoral period (parsed from link)
+    ct: int | None = None  # tisk number (parsed from link)
+    url: str = ""  # full URL to the bill's history page
+
+
+def scrape_proposed_law_changes(
+    period: int, ct: int,
+) -> list[ProposedLawChange]:
+    """Parse the law changes table at ``historie.sqw?snzp=1``.
+
+    Returns list of ProposedLawChange or empty list on failure.
+    """
+    url = PSP_LAW_CHANGES_URL_TEMPLATE.format(period=period, ct=ct)
+    logger.debug("Scraping law changes: {}", url)
+
+    try:
+        with httpx.Client(timeout=30, follow_redirects=True) as client:
+            resp = client.get(url)
+            resp.raise_for_status()
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Failed to fetch law changes for tisk {}/{}", period, ct,
+        )
+        return []
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    changes: list[ProposedLawChange] = []
+
+    # The page contains a table with law change info
+    # Look for tables with relevant content
+    for table in soup.find_all("table"):
+        rows = table.find_all("tr")
+        if len(rows) < 2:
+            continue
+
+        # Check if this looks like a law changes table
+        header = rows[0].get_text(strip=True).lower()
+        if "předpis" not in header and "citace" not in header and "zákon" not in header:
+            continue
+
+        for row in rows[1:]:
+            cells = row.find_all("td")
+            if len(cells) < 2:
+                continue
+
+            change = ProposedLawChange()
+
+            # Extract text from cells — layout varies, so be flexible
+            texts = [c.get_text(strip=True) for c in cells]
+            if len(texts) >= 1:
+                change.citace = texts[0]
+            if len(texts) >= 2:
+                change.zmena = texts[1]
+            if len(texts) >= 3:
+                change.predpis = texts[2]
+
+            # Look for idsb link in any cell
+            for cell in cells:
+                link = cell.find("a", href=_IDSB_RE)
+                if link:
+                    m = _IDSB_RE.search(link["href"])
+                    if m:
+                        change.idsb = int(m.group(1))
+                    break
+
+            # Skip empty rows
+            if not change.citace and not change.predpis:
+                continue
+
+            changes.append(change)
+
+    if not changes:
+        # Fallback: try to extract from any links with idsb parameter
+        for link in soup.find_all("a", href=_IDSB_RE):
+            m = _IDSB_RE.search(link["href"])
+            if m:
+                text = link.get_text(strip=True)
+                # Get surrounding text for context
+                parent_text = link.parent.get_text(strip=True) if link.parent else text
+                changes.append(ProposedLawChange(
+                    citace=text or parent_text,
+                    idsb=int(m.group(1)),
+                ))
+
+    logger.debug("Tisk {}/{}: found {} law changes", period, ct, len(changes))
+    return changes
+
+
+def scrape_related_bills(idsb: int) -> list[RelatedBill]:
+    """Parse the related bills table at ``tisky.sqw?idsb={id}``.
+
+    Returns list of RelatedBill or empty list on failure.
+    """
+    url = PSP_RELATED_BILLS_URL_TEMPLATE.format(idsb=idsb)
+    logger.debug("Scraping related bills: {}", url)
+
+    try:
+        with httpx.Client(timeout=30, follow_redirects=True) as client:
+            resp = client.get(url)
+            resp.raise_for_status()
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Failed to fetch related bills for idsb={}", idsb,
+        )
+        return []
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    bills: list[RelatedBill] = []
+
+    for table in soup.find_all("table"):
+        rows = table.find_all("tr")
+        if len(rows) < 2:
+            continue
+
+        for row in rows[1:]:
+            cells = row.find_all("td")
+            if not cells:
+                continue
+
+            bill = RelatedBill()
+            texts = [c.get_text(strip=True) for c in cells]
+
+            if len(texts) >= 1:
+                bill.cislo = texts[0]
+            if len(texts) >= 2:
+                bill.kratky_nazev = texts[1]
+            if len(texts) >= 3:
+                bill.typ_tisku = texts[2]
+            if len(texts) >= 4:
+                bill.stav = texts[3]
+
+            # Extract period and ct from any historie.sqw link in the row
+            for cell in cells:
+                link = cell.find("a", href=_HISTORIE_LINK_RE)
+                if link:
+                    m = _HISTORIE_LINK_RE.search(link["href"])
+                    if m:
+                        bill.period = int(m.group(1))
+                        bill.ct = int(m.group(2))
+                        bill.url = f"https://www.psp.cz/sqw/{link['href']}"
+                    break
+
+            if not bill.cislo and not bill.kratky_nazev:
+                continue
+
+            bills.append(bill)
+
+    logger.debug("idsb={}: found {} related bills", idsb, len(bills))
+    return bills
+
+
+# --- JSON caching ---
+
+
+def save_law_changes_json(
+    changes: list[ProposedLawChange],
+    period: int,
+    ct: int,
+    cache_dir: Path,
+) -> Path:
+    """Save law changes to ``tisky_meta/{period}/tisky_law_changes/{ct}.json``."""
+    dest_dir = cache_dir / TISKY_META_DIR / str(period) / TISKY_LAW_CHANGES_DIR
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"{ct}.json"
+    data = [asdict(c) for c in changes]
+    dest.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    return dest
+
+
+def load_law_changes_json(
+    period: int,
+    ct: int,
+    cache_dir: Path,
+) -> list[ProposedLawChange] | None:
+    """Load cached law changes. Returns None if not cached."""
+    path = cache_dir / TISKY_META_DIR / str(period) / TISKY_LAW_CHANGES_DIR / f"{ct}.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return [ProposedLawChange(**d) for d in data]
+    except Exception:
+        logger.opt(exception=True).warning("Failed to load law changes from {}", path)
+        return None
+
+
+def save_related_bills_json(
+    bills: list[RelatedBill],
+    idsb: int,
+    cache_dir: Path,
+) -> Path:
+    """Save related bills to ``tisky_meta/related_bills/{idsb}.json``."""
+    dest_dir = cache_dir / TISKY_META_DIR / TISKY_RELATED_BILLS_DIR
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"{idsb}.json"
+    data = [asdict(b) for b in bills]
+    dest.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    return dest
+
+
+def load_related_bills_json(
+    idsb: int,
+    cache_dir: Path,
+) -> list[RelatedBill] | None:
+    """Load cached related bills. Returns None if not cached."""
+    path = cache_dir / TISKY_META_DIR / TISKY_RELATED_BILLS_DIR / f"{idsb}.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return [RelatedBill(**d) for d in data]
+    except Exception:
+        logger.opt(exception=True).warning("Failed to load related bills from {}", path)
+        return None

--- a/pspcz_analyzer/data/tisk_scraper.py
+++ b/pspcz_analyzer/data/tisk_scraper.py
@@ -7,7 +7,7 @@ import httpx
 from bs4 import BeautifulSoup
 from loguru import logger
 
-from pspcz_analyzer.config import PSP_ORIG2_BASE_URL, PSP_TISKT_URL_TEMPLATE
+from pspcz_analyzer.config import PSP_ORIG2_BASE_URL, PSP_SUBTISKT_URL_TEMPLATE, PSP_TISKT_URL_TEMPLATE
 
 
 @dataclass
@@ -70,3 +70,110 @@ def get_best_pdf(period: int, ct: int) -> TiskDocument | None:
     # Prefer complete prints, then first available
     complete = [d for d in docs if d.is_complete]
     return complete[0] if complete else docs[0]
+
+
+@dataclass
+class SubTiskVersion:
+    """A sub-tisk version (CT1=0 original, CT1=1 gov opinion, CT1=2+ amendments)."""
+
+    period: int
+    ct: int
+    ct1: int
+    idd: int | None = None  # best PDF idd for this version
+    description: str = ""
+    has_pdf: bool = False
+    has_text: bool = False
+    llm_diff_summary: str = ""
+
+
+def _scrape_subtisk_page(period: int, ct: int, ct1: int) -> list[TiskDocument] | None:
+    """Scrape a single sub-tisk page. Returns documents or None if page doesn't exist."""
+    url = PSP_SUBTISKT_URL_TEMPLATE.format(period=period, ct=ct, ct1=ct1)
+    logger.debug("Scraping sub-tisk page: {}", url)
+
+    try:
+        with httpx.Client(timeout=30, follow_redirects=True) as client:
+            resp = client.get(url)
+            resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return None
+        logger.opt(exception=True).warning(
+            "Failed to fetch sub-tisk {}/{}/{}", period, ct, ct1,
+        )
+        return None
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Failed to fetch sub-tisk {}/{}/{}", period, ct, ct1,
+        )
+        return None
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    # Check for empty/error page — psp.cz returns 200 with minimal content
+    body_text = soup.get_text(strip=True)
+    if len(body_text) < 50 or "nebyl nalezen" in body_text.lower():
+        return None
+
+    documents: list[TiskDocument] = []
+    for link in soup.find_all("a", href=_IDD_RE):
+        href = link["href"]
+        match = _IDD_RE.search(href)
+        if not match:
+            continue
+        idd = int(match.group(1))
+        desc = link.get_text(strip=True)
+        parent_text = link.parent.get_text(strip=True) if link.parent else desc
+        fmt = "PDF" if "PDF" in parent_text.upper() or href.endswith(".pdf") else "unknown"
+        is_complete = "cel" in desc.lower() or "úplné znění" in desc.lower()
+        documents.append(TiskDocument(idd=idd, description=desc, format=fmt, is_complete=is_complete))
+
+    return documents
+
+
+def scrape_all_subtisk_documents(
+    period: int, ct: int, max_ct1: int = 20,
+) -> list[SubTiskVersion]:
+    """Iterate CT1=0..N for a tisk, collecting sub-tisk versions.
+
+    Stops when a page returns 404/empty. Returns list of SubTiskVersion.
+    """
+    versions: list[SubTiskVersion] = []
+
+    for ct1 in range(max_ct1 + 1):
+        docs = _scrape_subtisk_page(period, ct, ct1)
+        if docs is None and ct1 > 0:
+            # CT1=0 might legitimately have no PDFs, but once we hit empty
+            # for ct1 > 0, we're past the last version
+            break
+
+        # Build a description from the page's title/context
+        best_doc = None
+        desc = ""
+        if docs:
+            # Prefer complete docs
+            complete = [d for d in docs if d.is_complete]
+            best_doc = complete[0] if complete else docs[0]
+            desc = best_doc.description
+
+        if ct1 == 0:
+            desc = desc or "Původní znění (original)"
+        elif ct1 == 1:
+            desc = desc or "Stanovisko vlády (government opinion)"
+
+        version = SubTiskVersion(
+            period=period,
+            ct=ct,
+            ct1=ct1,
+            idd=best_doc.idd if best_doc else None,
+            description=desc,
+            has_pdf=best_doc is not None,
+        )
+        versions.append(version)
+
+        # If we got no docs for CT1=0, don't bother continuing
+        if docs is None and ct1 == 0:
+            break
+
+    logger.debug("Tisk {}/{}: found {} sub-tisk versions", period, ct, len(versions))
+    return versions

--- a/pspcz_analyzer/main.py
+++ b/pspcz_analyzer/main.py
@@ -53,6 +53,23 @@ app.include_router(pages_router)
 app.include_router(api_router, prefix="/api")
 app.include_router(charts_router, prefix="/charts")
 
+# Register shared Jinja2 filters on all template instances
+import markupsafe
+import markdown as _md
+
+def _md_filter(text: str) -> markupsafe.Markup:
+    """Convert markdown to HTML, safe for Jinja2 rendering."""
+    if not text:
+        return markupsafe.Markup("")
+    html = _md.markdown(text, extensions=["nl2br"])
+    return markupsafe.Markup(html)
+
+from pspcz_analyzer.routes.api import templates as api_templates
+from pspcz_analyzer.routes.pages import templates as pages_templates
+
+for t in (templates, api_templates, pages_templates):
+    t.env.filters["markdown"] = _md_filter
+
 
 def main() -> None:
     import uvicorn

--- a/pspcz_analyzer/services/votes_service.py
+++ b/pspcz_analyzer/services/votes_service.py
@@ -176,6 +176,8 @@ def vote_detail(data: PeriodData, vote_id: int) -> dict | None:
     info["tisk_topics"] = tisk.topics if tisk else []
     info["tisk_has_text"] = tisk.has_text if tisk else False
     info["tisk_summary"] = tisk.summary if tisk else ""
+    info["tisk_law_changes"] = tisk.law_changes if tisk else []
+    info["tisk_sub_versions"] = tisk.sub_versions if tisk else []
 
     # Legislative history and vote-to-stage matching
     info["tisk_history"] = (tisk.history if tisk else None)

--- a/pspcz_analyzer/static/style.css
+++ b/pspcz_analyzer/static/style.css
@@ -542,6 +542,51 @@ input:focus, select:focus {
 .timeline-approved { color: #2e7d32; }
 .timeline-rejected { color: #c62828; }
 
+/* Version diff summary (AI-generated markdown) */
+.version-diff-summary {
+    margin-top: 0.35rem;
+    padding: 0.5rem 0.75rem;
+    background: #f0f4f8;
+    border-left: 3px solid #1565c0;
+    border-radius: 0 0.25rem 0.25rem 0;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: #333;
+}
+
+.version-diff-summary p {
+    margin: 0.3rem 0;
+}
+
+.version-diff-summary p:first-child {
+    margin-top: 0;
+}
+
+.version-diff-summary p:last-child {
+    margin-bottom: 0;
+}
+
+.version-diff-summary h3,
+.version-diff-summary h4 {
+    font-size: 0.9rem;
+    margin: 0.5rem 0 0.2rem;
+    color: #1a237e;
+}
+
+.version-diff-summary strong {
+    color: #1a237e;
+}
+
+.version-diff-summary ul,
+.version-diff-summary ol {
+    margin: 0.2rem 0;
+    padding-left: 1.2rem;
+}
+
+.version-diff-summary li {
+    margin: 0.15rem 0;
+}
+
 /* ============================================================
    Methodology / Collapsible Details
    ============================================================ */

--- a/pspcz_analyzer/templates/partials/tisk_evolution.html
+++ b/pspcz_analyzer/templates/partials/tisk_evolution.html
@@ -1,0 +1,101 @@
+{% if law_changes or sub_versions %}
+<div class="legis-box" style="margin-top: 1rem;">
+    <div class="legis-box-header">
+        Legislative Evolution
+        <small>Law changes &amp; version history</small>
+    </div>
+
+    {% if law_changes %}
+    <div style="margin-bottom: 1rem;">
+        <h4 style="margin: 0.5rem 0; font-size: 0.95rem;">Proposed Law Changes</h4>
+        <div class="overflow-auto">
+            <table style="font-size: 0.85rem;">
+                <thead>
+                    <tr>
+                        <th>Citation</th>
+                        <th>Change Type</th>
+                        <th>Law</th>
+                        <th>Related Bills</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for lc in law_changes %}
+                    <tr>
+                        <td>{{ lc.citace or "—" }}</td>
+                        <td>{{ lc.zmena or "—" }}</td>
+                        <td>{{ lc.predpis or "—" }}</td>
+                        <td>
+                            {% if lc.idsb %}
+                            <button class="btn-outline btn-small"
+                                    hx-get="/api/related-bills?idsb={{ lc.idsb }}"
+                                    hx-target="#related-bills-{{ lc.idsb }}"
+                                    hx-swap="innerHTML"
+                                    hx-indicator="#rb-loading-{{ lc.idsb }}">
+                                Show related bills
+                            </button>
+                            <span id="rb-loading-{{ lc.idsb }}" class="htmx-indicator" aria-busy="true" style="font-size: 0.8rem;">Loading...</span>
+                            <div id="related-bills-{{ lc.idsb }}"></div>
+                            {% else %}
+                            —
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if sub_versions %}
+    <div>
+        <h4 style="margin: 0.5rem 0; font-size: 0.95rem;">Version History</h4>
+        <div class="legislative-timeline" style="margin-left: 0.5rem;">
+            {% for v in sub_versions %}
+            <div class="timeline-stage">
+                <div class="timeline-dot" {% if v.ct1 == 0 %}style="background: #1565c0;"{% endif %}></div>
+                <span class="timeline-label">
+                    <strong>CT1={{ v.ct1 }}
+                    {% if v.ct1 == 0 %}
+                    (Original)
+                    {% elif v.ct1 == 1 %}
+                    (Government opinion)
+                    {% else %}
+                    (Amendment {{ v.ct1 }})
+                    {% endif %}</strong>
+                </span>
+                {% if v.description %}
+                <span class="timeline-date">{{ v.description }}</span>
+                {% endif %}
+
+                {% if v.llm_diff_summary %}
+                <div class="version-diff-summary">
+                    {{ v.llm_diff_summary | markdown }}
+                </div>
+                {% endif %}
+
+                <div style="margin-top: 0.25rem; font-size: 0.8rem;">
+                    {% if v.has_pdf %}
+                    <span style="color: #2e7d32;">PDF available</span>
+                    {% endif %}
+                    {% if v.has_text %}
+                    <details style="margin-top: 0.25rem;">
+                        <summary style="cursor: pointer; font-size: 0.8rem;">View extracted text</summary>
+                        <div hx-get="/api/tisk-text?period={{ period }}&ct={{ ct }}&ct1={{ v.ct1 }}"
+                             hx-trigger="intersect once">
+                            <span class="htmx-indicator" aria-busy="true" style="font-size: 0.8rem;">Loading text...</span>
+                        </div>
+                    </details>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% else %}
+<p style="color: #6c757d; font-size: 0.85rem; margin-top: 0.5rem;">
+    No legislative evolution data available yet. The background pipeline will process this data automatically.
+</p>
+{% endif %}

--- a/pspcz_analyzer/templates/vote_detail.html
+++ b/pspcz_analyzer/templates/vote_detail.html
@@ -105,6 +105,13 @@
             <span id="tisk-loading" class="htmx-indicator" aria-busy="true">Loading transcription...</span>
         </div>
     </details>
+
+    <div id="tisk-evolution-content"
+         hx-get="/api/tisk-evolution?period={{ period }}&ct={{ detail.info.tisk_ct }}"
+         hx-trigger="intersect once"
+         hx-indicator="#evolution-loading">
+        <span id="evolution-loading" class="htmx-indicator" aria-busy="true">Loading legislative evolution...</span>
+    </div>
     {% endif %}
 
     <div class="stat-grid">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,5 @@ dependencies = [
     "beautifulsoup4>=4.12",
     "pymupdf>=1.25",
     "scalar-fastapi>=1.6.2",
+    "markdown>=3.10.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -533,6 +533,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -899,6 +908,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "loguru" },
+    { name = "markdown" },
     { name = "matplotlib" },
     { name = "polars" },
     { name = "pymupdf" },
@@ -915,6 +925,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "markdown", specifier = ">=3.10.2" },
     { name = "matplotlib", specifier = ">=3.9" },
     { name = "polars", specifier = ">=1.0" },
     { name = "pymupdf", specifier = ">=1.25" },


### PR DESCRIPTION
## Summary
- **New scraper** (`law_changes_scraper.py`): Scrapes "navržené změny předpisů" (proposed law changes) from `historie.sqw?snzp=1` and related bills from `tisky.sqw?idsb=...`
- **Sub-tisk version support**: Downloads all sub-tisk PDFs (CT1=0, 1, 2+), extracts text, tracks how bills evolve through readings
- **LLM version comparison**: Uses Ollama to generate Czech-language summaries of specific changes between consecutive bill versions (paragraph-level diffs)
- **Pipeline integration**: Three new pipeline stages (`_scrape_law_changes_sync`, `_download_subtisk_versions_sync`, `_analyze_version_diffs_sync`) integrated into `TiskPipelineService`
- **HTMX lazy-loaded UI**: New `/api/tisk-evolution` and `/api/related-bills` endpoints with `tisk_evolution.html` partial showing law changes table and version timeline
- **Markdown rendering**: Added `markdown` dependency for rendering LLM diff summaries in the UI

## Test plan
- [ ] Run `uv sync` to install new `markdown` dependency
- [ ] Start dev server with `uv run python -m pspcz_analyzer.main`
- [ ] Trigger pipeline for period 10 and verify law changes JSON files appear in `~/.cache/pspcz-analyzer/psp/tisky_meta/10/tisky_law_changes/`
- [ ] Verify sub-tisk PDFs download to `tisky_pdf/10/` with `{ct}_{ct1}.pdf` naming
- [ ] Navigate to a vote detail page linked to a multi-version tisk (e.g. tisk 77) and scroll to the evolution section
- [ ] Click "Show related bills" button and verify HTMX loads related bills table
- [ ] Expand sub-tisk version text and verify extracted text loads
- [ ] Verify LLM diff summaries render as formatted markdown (requires Ollama running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)