### PR TITLE
Add bilingual topic classification and sync docs

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -7,7 +7,7 @@ Czech Parliamentary Voting Analyzer — OSINT tool for downloading, parsing, and
 - **Python 3.14** (pinned in .python-version, requires >=3.12)
 - **Package manager**: uv
 - **Web**: FastAPI + Uvicorn + Jinja2 + HTMX
-- **CSS**: Pico CSS v2 (CDN, dark theme)
+- **CSS**: Pico CSS v2 (CDN, institutional light theme)
 - **Data**: Polars (DataFrames, Parquet caching)
 - **Charts**: Matplotlib + Seaborn (server-rendered PNG)
 - **HTTP client**: httpx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ Environment variables are loaded from `.env` via `python-dotenv` (see `.env.exam
 - `OLLAMA_MODEL` — model name (default: `qwen3:8b`)
 - `DAILY_REFRESH_ENABLED` — `1` to enable daily data refresh, `0` to disable (default: `1`)
 - `DAILY_REFRESH_HOUR` — hour (CET, 0-23) for daily refresh (default: `3`)
+- `GITHUB_FEEDBACK_ENABLED` — enable feedback form (`0` or `1`, default: `0`)
+- `GITHUB_FEEDBACK_TOKEN` — GitHub PAT for creating issues (default: empty)
+- `GITHUB_FEEDBACK_REPO` — target repository (default: `tadeasf/pspcz_analyzer`)
+- `GITHUB_FEEDBACK_LABELS` — labels for feedback issues (default: `user-feedback`)
+- `TISK_SHORTENER` — truncate tisk text for LLM (`0` = full text, `1` = truncate, default: `0`)
 
 ## Architecture
 
@@ -67,6 +72,15 @@ Each in `services/`, each takes a `PeriodData` and returns `list[dict]`:
 - **`attendance_service`** — Attendance %, vote breakdown (YES/NO/ABSTAINED), activity ranking
 - **`similarity_service`** — Cosine similarity + SVD-based PCA on vote matrix (MPs × votes, +1/-1/0)
 - **`votes_service`** — Vote search/list with pagination, vote detail with per-party breakdown
+
+### Feedback Service (`services/feedback_service.py`)
+
+Submits user feedback as GitHub Issues. Controlled by `GITHUB_FEEDBACK_ENABLED`. Requires a `GITHUB_FEEDBACK_TOKEN` with `public_repo` scope.
+
+### Security & Rate Limiting
+
+- **`middleware.py`** — `SecurityHeadersMiddleware` adds `X-Content-Type-Options`, `X-Frame-Options`, etc. Also `run_with_timeout` for ContextVar-safe thread execution.
+- **`rate_limit.py`** — Per-endpoint rate limits via slowapi (e.g. 15/min for analysis APIs, 3/hour for feedback).
 
 ### Web Layer
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -112,6 +112,7 @@ The `TiskInfo` dataclass (`models/tisk_models.py`) holds enriched data for each 
 | `nazev` | str | Print name |
 | `url` | str | psp.cz URL |
 | `topics` | list[str] | Topic labels (from LLM or keyword classification) |
+| `topics_en` | list[str] | English topic labels (from LLM or keyword classification) |
 | `summary` | str | Czech AI summary |
 | `summary_en` | str | English AI summary |
 | `has_text` | bool | Whether extracted PDF text exists |
@@ -135,7 +136,7 @@ Per-period topic classification stored as Parquet files:
 ~/.cache/pspcz-analyzer/psp/tisky_meta/{period}/topic_classifications.parquet
 ```
 
-Columns: `ct` (print number), `topic` (serialized topic labels), `summary` (Czech), `summary_en` (English), `source` (classification method).
+Columns: `ct` (print number), `topic` (serialized Czech topic labels), `topic_en` (serialized English topic labels), `summary` (Czech), `summary_en` (English), `source` (classification method).
 
 Topics are assigned either by keyword matching (`topic_service.py`) or by LLM classification (`ollama_service.py`). The LLM results take priority when available.
 
@@ -177,6 +178,11 @@ All configuration is via environment variables, loaded from `.env` by `python-do
 | `OLLAMA_MODEL` | `qwen3:8b` | Model for inference |
 | `DAILY_REFRESH_ENABLED` | `1` | `1` to enable daily data refresh, `0` to disable |
 | `DAILY_REFRESH_HOUR` | `3` | Hour (CET, 0-23) at which the daily refresh runs |
+| `GITHUB_FEEDBACK_ENABLED` | `0` | Enable user feedback via GitHub Issues |
+| `GITHUB_FEEDBACK_TOKEN` | *(empty)* | GitHub PAT with `public_repo` scope |
+| `GITHUB_FEEDBACK_REPO` | `tadeasf/pspcz_analyzer` | Repository for feedback issues |
+| `GITHUB_FEEDBACK_LABELS` | `user-feedback` | Labels applied to feedback issues |
+| `TISK_SHORTENER` | `0` | Truncate tisk text for LLM (`0` = full, `1` = truncate) |
 
 ### Ollama Configuration
 
@@ -230,6 +236,7 @@ Votes in the `zmatecne` table are void and are always filtered out before any an
     tisky_meta/       # Topic classification + summary Parquet caches
     tisky_historie/   # Legislative history JSON files
     tisky_version_diffs/  # LLM diff summaries (Czech + English)
+    tisky_related_bills/  # Related bills JSON files (from zakon.cz)
 ```
 
 The Parquet cache uses file modification times: if the Parquet file is newer than the source UNL directory, it's loaded directly. Otherwise the UNL files are re-parsed and the Parquet is regenerated.

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ The app runs at `http://localhost:8000`. Configure `OLLAMA_BASE_URL` and `OLLAMA
 | Web framework | FastAPI + Uvicorn |
 | Templating | Jinja2 + i18n extension |
 | Frontend interactivity | HTMX |
-| CSS | Pico CSS (dark theme) |
+| CSS | Pico CSS (institutional light theme) |
 | Localization | Dict-based i18n (Czech + English) |
 | Data processing | Polars |
 | Charts | Seaborn + Matplotlib |

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -22,7 +22,7 @@ All pages extend `base.html`, which provides:
 - **Navigation**: Logo + "PSP.cz Analyzer" branding, page links, API Docs link, period selector
 - **Language switcher**: CZ/EN toggle links in the header (active language highlighted)
 - **Footer**: data source attribution + educational project disclaimer (separated by CSS border)
-- **Theme**: Pico CSS dark mode (`data-theme="dark"`)
+- **Theme**: Pico CSS light mode (institutional theme, `data-theme="light"`)
 
 Active navigation item is highlighted via `aria-current="page"`, controlled by the `active_page` template variable.
 
@@ -54,6 +54,7 @@ The most complex template. Displays:
 9. **Vote counts** — stat cards (For/Against/Abstained/Did not vote)
 10. **Party breakdown** — table with per-party vote counts
 11. **Individual MPs** — collapsible table of all MP votes with color-coded results
+12. **Feedback form** — user feedback submission form (when `GITHUB_FEEDBACK_ENABLED=1`)
 
 ## Partials (`templates/partials/`)
 
@@ -66,6 +67,8 @@ HTML fragments returned by `/api/*` endpoints for HTMX swaps:
 | `similarity_table.html` | `/api/similarity` | Table of cross-party MP pairs by similarity |
 | `votes_list.html` | `/api/votes` | Paginated vote rows with tisk links |
 | `tisk_evolution.html` | `/api/tisk-evolution` | Sub-version comparison with bilingual diff summaries |
+| `feedback_form.html` | `/api/feedback` (form) | Feedback submission form with title/body fields |
+| `feedback_result.html` | `/api/feedback` (result) | Success/error message after feedback submission |
 
 ## HTMX Pattern
 
@@ -106,11 +109,11 @@ The skeleton is shown immediately on period change (`switchPeriod()`) and on nav
 
 ## Charts
 
-Chart images are embedded as `<img>` tags pointing to `/charts/*.png` endpoints. They render server-side via matplotlib/seaborn with a dark theme matching the UI (`#1a1a2e` background). Chart labels and titles are localized via `gettext()`.
+Chart images are embedded as `<img>` tags pointing to `/charts/*.png` endpoints. They render server-side via matplotlib/seaborn with a light theme (`#FFFFFF` background with `#F7F7F7` plot area). Chart labels and titles are localized via `gettext()`.
 
 ## Styling
 
-All custom CSS lives in `/static/style.css` (external file). Pico CSS v2 dark theme is the base. Key customizations:
+All custom CSS lives in `/static/style.css` (external file). Pico CSS v2 light theme is the base. Key customizations:
 
 - `--pico-border-radius: 0.25rem` — sharper corners for a more formal/institutional feel
 - Legislative timeline styles (dots, lines, active glow)
@@ -119,6 +122,9 @@ All custom CSS lives in `/static/style.css` (external file). Pico CSS v2 dark th
 - Navigation period selector styling
 - Language switcher (`.lang-switcher`) — flex layout with active state highlight
 - Footer with CSS border separator (no `<hr>`)
+- Blue gradient navigation bar with institutional feel
+- Georgia font for headings
+- Zebra-striped tables for readability
 
 ## Methodology Sections
 

--- a/pspcz_analyzer/models/tisk_models.py
+++ b/pspcz_analyzer/models/tisk_models.py
@@ -18,6 +18,7 @@ class TiskInfo:
         nazev: Title of the tisk.
         period: Electoral period number.
         topics: LLM-classified topic labels (1-3 Czech labels).
+        topics_en: LLM-classified topic labels (1-3 English labels).
         has_text: Whether extracted full text is available.
         summary: LLM-generated Czech summary of the tisk.
         history: Scraped legislative history stages.
@@ -30,6 +31,7 @@ class TiskInfo:
     nazev: str
     period: int
     topics: list[str] = field(default_factory=list)
+    topics_en: list[str] = field(default_factory=list)
     has_text: bool = False
     summary: str = ""
     summary_en: str = ""
@@ -82,9 +84,17 @@ class PeriodData:
         """Get tisk info for a vote given its session and agenda item numbers."""
         return self.tisk_lookup.get((schuze, bod))
 
-    def get_all_topic_labels(self) -> list[str]:
-        """Collect all unique topic labels across all tisky, sorted."""
+    def get_all_topic_labels(self, lang: str = "cs") -> list[str]:
+        """Collect all unique topic labels across all tisky, sorted.
+
+        Args:
+            lang: Language code ('cs' or 'en'). Uses English labels when
+                  available and lang == 'en', otherwise Czech.
+        """
         labels: set[str] = set()
         for tisk in self.tisk_lookup.values():
-            labels.update(tisk.topics)
+            if lang == "en" and tisk.topics_en:
+                labels.update(tisk.topics_en)
+            else:
+                labels.update(tisk.topics)
         return sorted(labels)

--- a/pspcz_analyzer/routes/api.py
+++ b/pspcz_analyzer/routes/api.py
@@ -131,11 +131,12 @@ async def votes_api(
     validate_period(period)
     data_svc = request.app.state.data
     pd = data_svc.get_period(period)
-    key = f"votes:{period}:{search}:{outcome}:{topic}:{page}"
+    lang = getattr(request.state, "lang", "cs")
+    key = f"votes:{period}:{search}:{outcome}:{topic}:{page}:{lang}"
     result = analysis_cache.get_or_compute(
         key,
         lambda: list_votes(
-            pd, search=search, page=page, outcome_filter=outcome, topic_filter=topic
+            pd, search=search, page=page, outcome_filter=outcome, topic_filter=topic, lang=lang
         ),
     )
     return templates.TemplateResponse(
@@ -146,7 +147,7 @@ async def votes_api(
             "search": search,
             "outcome": outcome,
             "topic": topic,
-            "lang": getattr(request.state, "lang", "cs"),
+            "lang": lang,
             **result,
         },
     )

--- a/pspcz_analyzer/routes/pages.py
+++ b/pspcz_analyzer/routes/pages.py
@@ -90,9 +90,10 @@ async def votes_page(request: Request, period: int = DEFAULT_PERIOD):
     validate_period(period)
     data_svc = request.app.state.data
     pd = data_svc.get_period(period)
+    lang = getattr(request.state, "lang", "cs")
     return templates.TemplateResponse(
         "votes.html",
-        _ctx(request, period, active_page="votes", topics=pd.get_all_topic_labels()),
+        _ctx(request, period, active_page="votes", topics=pd.get_all_topic_labels(lang)),
     )
 
 
@@ -102,7 +103,8 @@ async def vote_detail_page(request: Request, vote_id: int, period: int = DEFAULT
     validate_period(period)
     data_svc = request.app.state.data
     pd = data_svc.get_period(period)
-    detail = vote_detail(pd, vote_id)
+    lang = getattr(request.state, "lang", "cs")
+    detail = vote_detail(pd, vote_id, lang)
     if detail is None:
         return templates.TemplateResponse(
             "votes.html",

--- a/pspcz_analyzer/services/data_service.py
+++ b/pspcz_analyzer/services/data_service.py
@@ -314,6 +314,7 @@ class DataService:
             self._cache_mgr.topic_cache,
             self._cache_mgr.summary_cache,
             self._cache_mgr.summary_en_cache,
+            self._cache_mgr.topic_en_cache,
         )
 
         pd = PeriodData(

--- a/pspcz_analyzer/services/topic_service.py
+++ b/pspcz_analyzer/services/topic_service.py
@@ -317,11 +317,11 @@ def classify_tisk(text: str, title: str) -> list[tuple[str, int]]:
     return results
 
 
-def classify_tisk_primary_label(text: str, title: str) -> str | None:
-    """Return the Czech label of the best-matching topic, or None."""
+def classify_tisk_primary_label(text: str, title: str) -> tuple[str, str] | None:
+    """Return (label_cs, label_en) of the best-matching topic, or None."""
     results = classify_tisk(text, title)
     if not results:
         return None
     topic_id = results[0][0]
-    label_cs, _, _ = TOPIC_TAXONOMY[topic_id]
-    return label_cs
+    label_cs, label_en, _ = TOPIC_TAXONOMY[topic_id]
+    return label_cs, label_en


### PR DESCRIPTION
## Summary

- **Bilingual topics**: Topic classification now produces both Czech and English labels via Ollama LLM (with keyword fallback from `TOPIC_TAXONOMY`). English labels stored in Parquet (`topic_en` column), cached, and displayed when the user switches to English UI.
- **Docs sync**: All 7 documentation files updated to reflect recent features (feedback, rate limiting, security headers, legislative evolution) and the dark-to-light theme migration.
- **Language-aware UI**: Votes page topic filter dropdown and vote detail topic badges show English labels when `lang=en`.

### Code changes (8 files)
- `ollama_service.py` — English classification/consolidation prompts + bilingual methods
- `topic_service.py` — `classify_tisk_primary_label()` returns `(cs, en)` tuple
- `tisk_models.py` — `topics_en` field on `TiskInfo`, `get_all_topic_labels(lang)`
- `tisk_classifier.py` — Bilingual Parquet storage + consolidation
- `tisk_cache_manager.py` — `topic_en_cache` loading
- `tisk_lookup_builder.py` — Propagates `topics_en` to `TiskInfo`
- `votes_service.py` — `lang` param for language-aware topic selection
- `routes/api.py` + `routes/pages.py` — Pass `lang` through to services

### Docs changes (7 files)
- `README.md`, `CLAUDE.md`, `docs/routes.md`, `docs/services.md`, `docs/templates.md`, `docs/data-model.md`, `docs/index.md`

## Test plan

- [x] `ruff format` + `ruff check` — all clean
- [x] `pytest -m "not integration"` — 80 tests pass
- [x] No stale "dark" theme references in docs
- [ ] Manual: start app, switch to English, verify topic badges show English labels on vote detail page
- [ ] Manual: check votes page topic filter dropdown shows English labels when in EN mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)