### PR TITLE
Capture more amendment votes per bill from steno

### DIFF
--- a/pspcz_analyzer/config.py
+++ b/pspcz_analyzer/config.py
@@ -118,6 +118,12 @@ PSP_REQUEST_DELAY = 1.0  # seconds between requests to psp.cz
 # voting is at the END of a bod's discussion, so when a bod exceeds this we keep
 # the LAST N sub-pages. Prevents pathological 100-220 page bods from flooding I/O.
 STENO_MAX_SUBPAGES_PER_BOD = 250
+# Day-page TOCs link steno sub-pages by speaker anchor, so voting-continuation
+# pages (no speaker) are skipped. After collecting linked sub-pages we fill
+# numeric gaps no larger than this between consecutive collected pages, so e.g.
+# s017212 between s017211 and s017213 is fetched. Small bound keeps it from
+# bridging unrelated segments (e.g. votes split across two sitting days).
+STENO_SUBPAGE_GAP_FILL = 3
 
 # LLM provider selection: "ollama" (default) or "openai" (any OpenAI-compatible API)
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", "ollama")

--- a/pspcz_analyzer/services/amendments/merger.py
+++ b/pspcz_analyzer/services/amendments/merger.py
@@ -192,6 +192,11 @@ def _merge_pdf_and_steno(
         if not pdf_amendments:
             continue
 
+        # Only surface PDF-only amendments when steno linked at least one vote for
+        # this bill — otherwise a wholesale steno failure would dump the entire PDF
+        # as unvoted rows.
+        has_steno_votes = any(a.vote_number for a in bill.amendments)
+
         # Build steno lookup by letter (uppercase, stripped)
         steno_by_letter: dict[str, AmendmentVote] = {}
         for amend in bill.amendments:
@@ -232,8 +237,23 @@ def _merge_pdf_and_steno(
                         steno_item.submitter_names = list(pdf_amend.submitter_names)
                     merged.append(steno_item)
                     total_pdf_matched += 1
+            elif has_steno_votes:
+                # PDF-only: a submitted amendment we couldn't tie to a recorded
+                # vote. Surface it as an unvoted entry (vote_number=0 keeps it out
+                # of vote-ID resolution) so the bill shows its full amendment list.
+                merged.append(
+                    AmendmentVote(
+                        letter=pdf_amend.letter.strip().upper(),
+                        vote_number=0,
+                        result="",
+                        amendment_text=pdf_amend.raw_text,
+                        submitter_names=list(pdf_amend.submitter_names),
+                        pdf_submitter_names=list(pdf_amend.submitter_names),
+                    )
+                )
+                total_pdf_only += 1
             else:
-                # PDF-only: no steno match → no vote linkage, skip
+                # No steno votes at all for this bill → don't dump the PDF.
                 total_pdf_only += 1
 
         # Append steno-only leftovers (oral amendments not in PDF)

--- a/pspcz_analyzer/services/amendments/steno_parser.py
+++ b/pspcz_analyzer/services/amendments/steno_parser.py
@@ -37,11 +37,13 @@ _LETTER_RE = re.compile(
 )
 
 # Fallback letter regex: catches letters after "návrhu/návrh" without "písmenem"
-# e.g. "pozměňovací návrh A pan poslanec Nacher"
+# e.g. "pozměňovací návrh A pan poslanec Nacher", "k pozměňovacímu návrhu C)".
+# The mandatory "návrh" prefix keeps this from matching stray capitals such as
+# a name initial ("poslanec Mgr. A. Novák"); only the trailing context is widened.
 _LETTER_FALLBACK_RE = re.compile(
     r"(?:pozměňovac\w+\s+)?návrh\w*\s+"
     r"([A-Z]\d?(?:(?:,\s*|\s+a\s+)[A-Z]\d?)*)"
-    r"(?:\s+pan|\s+poslanc|\s*[,.]|\s+(?:Stanovisko|předložen))",
+    r"(?:\s+pan|\s+poslanc|\s*[,.)]|\s+(?:Stanovisko|předložen|který|jež|jenž))",
     re.IGNORECASE,
 )
 
@@ -78,12 +80,24 @@ _PAREN_STANCE_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Vote result with vote number — allows "Hlasování (číslo N)" paren format
+# Vote number anchor — "Hlasování číslo N" / "Hlasování (číslo N)" / "č. N".
+# Every announced vote carries this regardless of result phrasing; used to COUNT
+# announced votes (multi-day detection) independently of whether a result matched.
+_VOTE_NUMBER_RE = re.compile(r"[Hh]lasování\s+\(?(?:číslo|č\.)\s*(\d+)")
+
+# Vote result with vote number — allows "Hlasování (číslo N)" paren format.
+# The result alternation is broad: beyond bare "Přijato/Zamítnuto" it covers the
+# "(ne)byl přijat/zamítnut" and "Konstatuji, že …" phrasings chairs use, so votes
+# whose result is announced in a non-standard way still produce a block.
 _VOTE_RESULT_RE = re.compile(
     r"[Hh]lasování\s+\(?(?:číslo|č\.)\s*(\d+)"
     r".*?"
-    r"(Přijato|Zamítnuto|Návrh\s+byl\s+přijat|Návrh\s+nebyl\s+přijat)",
-    re.DOTALL,
+    r"(Přijato"
+    r"|Zamítnuto"
+    r"|[Nn]ávrh\s+(?:byl\s+|nebyl\s+)?(?:přijat|zamítnut)\w*"
+    r"|[Kk]onstatuji[,\s]+že\s+návrh\s+(?:byl\s+|nebyl\s+)?(?:přijat|zamítnut)\w*"
+    r"|s\s+návrhem\s+(?:byl\s+vysloven\s+souhlas|nebyl\s+vysloven\s+souhlas))",
+    re.IGNORECASE | re.DOTALL,
 )
 
 # Final passage vote — "zákon jako celku"
@@ -191,25 +205,42 @@ def _clean_html(html: str) -> str:
     return text.strip()
 
 
+def _count_votes(text: str) -> int:
+    """Count announced votes ("Hlasování číslo N") in a text span.
+
+    Args:
+        text: Cleaned steno text.
+
+    Returns:
+        Number of vote-number anchors found.
+    """
+    return sum(1 for _ in _VOTE_NUMBER_RE.finditer(text))
+
+
 def _extract_section(text: str) -> str:
     """Narrow cleaned steno text to the amendment voting section.
 
     When the start marker is present, slice from it to drop preceding debate
-    (reduces noise). When it is ABSENT, fall back to the full text rather than
-    discarding everything — block-splitting keeps only vote-numbered blocks and
-    cross-validation against the official vote numbers filters the rest, so a
-    bare-opening voting block is still recovered.
+    (reduces noise) — UNLESS voting also happens before the marker, which means
+    the bill was voted across multiple days and the first marker belongs to a
+    later day. In that case keep the full text so earlier-day votes are not
+    discarded. When no marker is present, keep the full text too: block-splitting
+    only retains vote-numbered blocks, so a bare-opening voting block still parses.
 
     Args:
         text: Full cleaned steno text.
 
     Returns:
-        The voting section (sliced) or the full text when no marker is found.
+        The voting section (sliced) or the full text.
     """
     match = _START_RE.search(text)
     if not match:
         return text
-    return text[match.start() :]
+    sliced = text[match.start() :]
+    # Votes before the marker (multi-day) → the slice would drop them.
+    if _count_votes(text) > _count_votes(sliced):
+        return text
+    return sliced
 
 
 def _normalize_result(raw: str) -> str:
@@ -222,10 +253,16 @@ def _normalize_result(raw: str) -> str:
         Normalized result: "accepted", "rejected", or "unknown".
     """
     lower = raw.lower().strip()
+    # Rejection phrasings first — some contain the substring "přijat"
+    # (e.g. "návrh nebyl přijat"), so they must win over the "přijat" check.
+    if "nebyl přijat" in lower or "nepřijat" in lower or "zamítnut" in lower or "neprošel" in lower:
+        return "rejected"
     if "přijat" in lower:
         return "accepted"
-    if "zamítnut" in lower:
+    if "nesouhlas" in lower:
         return "rejected"
+    if "souhlas" in lower:
+        return "accepted"
     return "unknown"
 
 
@@ -251,9 +288,10 @@ def _parse_letter_groups(letter_str: str) -> tuple[str, list[str]]:
 def _split_into_blocks(section: str) -> list[str]:
     """Split the amendment section into blocks at each vote result.
 
-    Each block contains the letter introduction, vote number, and result.
-    Splits AFTER each vote result so that text following a result (e.g.
-    the next amendment's introduction) belongs to the next block.
+    Each block contains the letter introduction, vote number, and result, in
+    that order (intro precedes the number, result follows it), so a block maps
+    cleanly to one amendment. Splits AFTER each vote result so text following a
+    result (the next amendment's introduction) belongs to the next block.
 
     Args:
         section: The amendment voting section text.
@@ -514,9 +552,14 @@ def parse_steno_amendments(
 
     # Narrow to the voting section. A missing start marker is no longer fatal:
     # _extract_section falls back to the full text and we lower confidence.
-    if not _START_RE.search(text):
+    marker = _START_RE.search(text)
+    if not marker:
         warnings.append("No explicit amendment-voting start marker; parsed full bod text")
         confidence -= 0.1
+    elif _count_votes(text) > _count_votes(text[marker.start() :]):
+        # Marker present but votes also precede it → multi-day voting.
+        warnings.append("Multi-day voting detected; parsed full bod text")
+        confidence -= 0.05
     section = _extract_section(text)
 
     # Split into blocks — no vote-numbered blocks means genuinely no votes here.

--- a/pspcz_analyzer/services/amendments/steno_scraper.py
+++ b/pspcz_analyzer/services/amendments/steno_scraper.py
@@ -28,6 +28,7 @@ from pspcz_analyzer.config import (
     PERIOD_YEARS,
     PSP_REQUEST_DELAY,
     STENO_MAX_SUBPAGES_PER_BOD,
+    STENO_SUBPAGE_GAP_FILL,
     UNL_ENCODING,
 )
 
@@ -54,6 +55,9 @@ _DAY_PAGE_LINK_RE = re.compile(r'href="((\d+-\d+)\.html(?:#(q\d+))?)"', re.IGNOR
 
 # Regex for steno sub-page links in day-pages: href="s045062.htm#r1"
 _SUBPAGE_LINK_RE = re.compile(r'href="(s\d+\.htm)', re.IGNORECASE)
+
+# Parses a sub-page filename into its numeric part: "s017212.htm" -> "017212".
+_SUBPAGE_NUM_RE = re.compile(r"^s(\d+)\.htm$", re.IGNORECASE)
 
 # Encoding for steno HTML (matches UNL encoding)
 _STENO_ENCODINGS = ["windows-1250", "iso-8859-2", "utf-8"]
@@ -381,6 +385,46 @@ def _download_subpage(
 # ── Public API ────────────────────────────────────────────────────────────
 
 
+def _fill_subpage_gaps(subpages: list[str], max_gap: int) -> list[str]:
+    """Fill small numeric gaps between collected steno sub-pages.
+
+    Day-page TOCs link sub-pages by speaker, so a voting-continuation page (no
+    speaker anchor) is skipped even though it sits mid-bod. Given the collected
+    pages, insert any sub-page whose number falls in a gap of at most ``max_gap``
+    between two consecutive collected pages (e.g. s017212 between s017211 and
+    s017213). Larger gaps (separate sitting days/segments) are left alone.
+
+    Args:
+        subpages: Collected sub-page filenames, any order.
+        max_gap: Largest numeric gap to bridge.
+
+    Returns:
+        Sub-page filenames including fillers, in ascending numeric order;
+        any names that don't parse are kept (ordered first).
+    """
+    parsed: list[tuple[int, int, str]] = []  # (number, zero-pad width, name)
+    unparsed: list[str] = []
+    for name in subpages:
+        m = _SUBPAGE_NUM_RE.match(name)
+        if m:
+            digits = m.group(1)
+            parsed.append((int(digits), len(digits), name))
+        else:
+            unparsed.append(name)
+    if not parsed:
+        return subpages
+    parsed.sort(key=lambda t: t[0])
+
+    result: list[str] = []
+    for i, (num, width, name) in enumerate(parsed):
+        result.append(name)
+        if i + 1 < len(parsed):
+            nxt = parsed[i + 1][0]
+            if 1 < nxt - num <= max_gap:
+                result.extend(f"s{n:0{width}d}.htm" for n in range(num + 1, nxt))
+    return [*unparsed, *result]
+
+
 def _collect_bod_subpages(
     index_html: str,
     base_url: str,
@@ -432,6 +476,21 @@ def _collect_bod_subpages(
             if sp not in seen:
                 seen.add(sp)
                 all_subpages.append(sp)
+
+    if all_subpages:
+        filled = _fill_subpage_gaps(all_subpages, STENO_SUBPAGE_GAP_FILL)
+        added = [p for p in filled if p not in seen]
+        if added:
+            logger.debug(
+                "[amendment pipeline] Gap-filled {} continuation sub-page(s) for "
+                "period={} schuze={} bod={}: {}",
+                len(added),
+                period,
+                schuze,
+                bod,
+                added,
+            )
+        all_subpages = filled
     return all_subpages
 
 

--- a/tests/unit/services/test_merger.py
+++ b/tests/unit/services/test_merger.py
@@ -1,0 +1,36 @@
+"""Tests for PDF↔steno amendment merge."""
+
+from pspcz_analyzer.models.amendment_models import AmendmentVote, BillAmendmentData
+from pspcz_analyzer.services.amendments.merger import _merge_pdf_and_steno
+from pspcz_analyzer.services.amendments.pdf_parser import PdfAmendment
+
+
+def _bill(amendments: list[AmendmentVote]) -> BillAmendmentData:
+    return BillAmendmentData(period=10, schuze=17, bod=2, ct=82, amendments=amendments)
+
+
+class TestMergePdfAndSteno:
+    def test_pdf_only_surfaced_when_bill_has_steno_votes(self):
+        bill = _bill([AmendmentVote(letter="A", vote_number=51, result="accepted")])
+        pdf = {
+            82: [
+                PdfAmendment(letter="A", raw_text="text A"),
+                PdfAmendment(letter="B", raw_text="text B", submitter_names=["Jan Novák"]),
+            ]
+        }
+        _merge_pdf_and_steno([bill], pdf)
+
+        by_letter = {a.letter: a for a in bill.amendments}
+        assert by_letter["A"].vote_number == 51  # matched to steno vote
+        # B had no steno vote → surfaced as an unvoted entry, not dropped.
+        assert "B" in by_letter
+        assert by_letter["B"].vote_number == 0
+        assert by_letter["B"].amendment_text == "text B"
+        assert by_letter["B"].submitter_names == ["Jan Novák"]
+
+    def test_pdf_only_suppressed_when_no_steno_votes(self):
+        # Steno produced no vote-linked amendments → don't dump the whole PDF.
+        bill = _bill([])
+        pdf = {82: [PdfAmendment(letter="B", raw_text="text B")]}
+        _merge_pdf_and_steno([bill], pdf)
+        assert bill.amendments == []

--- a/tests/unit/services/test_steno_parser.py
+++ b/tests/unit/services/test_steno_parser.py
@@ -658,3 +658,66 @@ class TestCrossValidateAmendments:
         letters = [a.letter for a in result]
         assert "C" in letters
         assert any("C" in w for w in warnings)
+
+
+# Votes on two sitting days: vote 46 (day 1) precedes the first start marker
+# (day 2). The slice would drop vote 46 — full text must be kept.
+STENO_MULTI_DAY = """
+<html><body>
+<p>První den. Sněmovna rozhodla. Hlasování číslo 46. Přijato. Pro 150, proti 10.</p>
+<p>Druhý den. Budeme hlasovat o pozměňovacím návrhu označeném písmenem A.
+Hlasování číslo 51. Přijato. Pro 120, proti 30.</p>
+</body></html>
+"""
+
+# Varied result phrasings the broadened regex must catch.
+STENO_CONTINUATION_PHRASINGS = """
+<html><body>
+<p>Přikročíme k hlasování.</p>
+<p>Návrh pod písmenem D. Hlasování číslo 60. Konstatuji, že návrh byl přijat.</p>
+<p>Návrh pod písmenem E. Hlasování číslo 61. Návrh nebyl přijat.</p>
+<p>Návrh pod písmenem F. Hlasování číslo 62. Zamítnuto.</p>
+</body></html>
+"""
+
+# Letter introduced without "písmenem", plus a name initial that must NOT
+# be picked up as a letter.
+STENO_LETTER_VARIANTS = """
+<html><body>
+<p>Přikročíme k hlasování.</p>
+<p>K pozměňovacímu návrhu C, pan poslanec Svoboda.
+Hlasování číslo 70. Přijato.</p>
+<p>Pan poslanec Mgr. A. Novák vystoupil k věci.
+Hlasování číslo 71. Přijato.</p>
+</body></html>
+"""
+
+
+class TestMultiDayAndPhrasings:
+    def test_multi_day_keeps_pre_marker_votes(self):
+        amendments, _conf, warns = parse_steno_amendments(STENO_MULTI_DAY)
+        nums = {a.vote_number for a in amendments}
+        assert 46 in nums  # day-1 vote, before the day-2 start marker
+        assert 51 in nums
+        assert any("Multi-day" in w for w in warns)
+
+    def test_extract_section_keeps_full_text_multi_day(self):
+        section = _extract_section(_clean_html(STENO_MULTI_DAY))
+        assert "číslo 46" in section  # not trimmed away
+
+    def test_varied_result_phrasings_captured(self):
+        amendments, _conf, _warns = parse_steno_amendments(STENO_CONTINUATION_PHRASINGS)
+        by_num = {a.vote_number: a.result for a in amendments}
+        assert by_num.get(60) == "accepted"  # "Konstatuji, že návrh byl přijat"
+        assert by_num.get(61) == "rejected"  # "Návrh nebyl přijat"
+        assert by_num.get(62) == "rejected"  # "Zamítnuto"
+
+    def test_letter_variant_extracted(self):
+        amendments, _conf, _warns = parse_steno_amendments(STENO_LETTER_VARIANTS)
+        by_num = {a.vote_number: a.letter for a in amendments}
+        assert by_num.get(70) == "C"
+
+    def test_name_initial_not_treated_as_letter(self):
+        amendments, _conf, _warns = parse_steno_amendments(STENO_LETTER_VARIANTS)
+        by_num = {a.vote_number: a.letter for a in amendments}
+        assert by_num.get(71) == ""  # "Mgr. A. Novák" must not yield letter "A"

--- a/tests/unit/services/test_steno_scraper.py
+++ b/tests/unit/services/test_steno_scraper.py
@@ -10,6 +10,7 @@ from pspcz_analyzer.services.amendments import steno_scraper
 from pspcz_analyzer.services.amendments.steno_scraper import (
     StenoFailure,
     _collect_bod_subpages,
+    _fill_subpage_gaps,
     _index_anchors_by_page,
     _subpage_span_for_bod,
     find_steno_for_bod,
@@ -119,3 +120,47 @@ class TestFindStenoForBod:
         assert first_url.endswith("s300.htm")
         assert "CONTENT s100.htm" not in html
         assert "CONTENT s301.htm" in html
+
+
+class TestFillSubpageGaps:
+    def test_fills_small_gap(self):
+        # The real case: s017212 (no speaker anchor) between linked pages.
+        out = _fill_subpage_gaps(["s017211.htm", "s017213.htm"], 3)
+        assert out == ["s017211.htm", "s017212.htm", "s017213.htm"]
+
+    def test_does_not_bridge_large_gap(self):
+        # 29 May (s017158) vs 3 June (s017211) — different sitting days, gap ~50.
+        out = _fill_subpage_gaps(["s017158.htm", "s017211.htm"], 3)
+        assert out == ["s017158.htm", "s017211.htm"]
+
+    def test_preserves_zero_pad_width(self):
+        out = _fill_subpage_gaps(["s017211.htm", "s017214.htm"], 3)
+        assert out == ["s017211.htm", "s017212.htm", "s017213.htm", "s017214.htm"]
+
+    def test_consecutive_pages_unchanged(self):
+        out = _fill_subpage_gaps(["s100.htm", "s101.htm"], 3)
+        assert out == ["s100.htm", "s101.htm"]
+
+    def test_sorts_and_handles_short_names(self):
+        out = _fill_subpage_gaps(["s103.htm", "s100.htm"], 3)
+        assert out == ["s100.htm", "s101.htm", "s102.htm", "s103.htm"]
+
+
+# Day 3 variant: TOC links s300 and s302 but NOT the continuation page s301.
+DAY3_GAP_HTML = """
+<html><body>
+<a name="q300"></a> <a href="s300.htm">řečník</a> <a href="s302.htm">pokračování</a>
+<a name="q400"></a> <a href="s400.htm">bod 3</a>
+</body></html>
+"""
+
+
+class TestCollectBodSubpagesGapFill:
+    def test_collects_unlinked_continuation_page(self, monkeypatch):
+        _patch_downloads(
+            monkeypatch, day_pages={"17-1.html": DAY1_HTML, "17-3.html": DAY3_GAP_HTML}
+        )
+        subs = _collect_bod_subpages(INDEX_HTML, "base/", 10, 17, 2, Path("/tmp"))
+        # s301 was never linked in the TOC but is gap-filled between s300 and s302.
+        assert "s301.htm" in subs
+        assert subs == ["s100.htm", "s101.htm", "s300.htm", "s301.htm", "s302.htm"]


### PR DESCRIPTION
Improves per-bill amendment coverage. After the previous fix linked amendments to votes at all, individual bills still under-captured (e.g. tisk 82 showed 2 of ~24 votes). This addresses four compounding causes in steno collection, parsing, and merge.

## Changes

- **Scraper gap-fill:** fetch voting-continuation sub-pages the day-page TOC omits (they have no speaker anchor), filling small numeric gaps between collected pages, bounded by the new `STENO_SUBPAGE_GAP_FILL` config.
- **Multi-day voting:** the parser keeps the full bod text when votes precede the first start marker, instead of slicing them away.
- **Broader vote parsing:** more result phrasings (`Konstatuji, že…`, `(ne)byl přijat/zamítnut`), a rejection-first `_normalize_result` (fixes "nebyl přijat" misread as accepted), and conservative letter-fallback widening.
- **Merge completeness:** PDF-listed amendments with no matching steno vote are surfaced as unvoted entries (`vote_number=0`) when the bill has at least one steno-linked vote, so the full amendment list shows.

Period 10 result: tisk 82 (17,2) 2 → 11 amendments, tisk 90 (17,1) 10 → 17, no regressions.