### PR TITLE
fix(security): trusted-proxy XFF, secure cookies, admin CSRF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,9 +138,20 @@ ADMIN_USERNAME=admin
 ADMIN_PASSWORD_HASH=
 
 # Comma-separated IP/CIDR whitelist for admin access.
-# Docker bridge network (172.16.0.0/12) is included by default.
-ADMIN_ALLOWED_IPS=127.0.0.1,::1,172.16.0.0/12
+# Loopback only by default — add your LAN/proxy CIDR explicitly if needed
+# (e.g. 127.0.0.1,::1,172.16.0.0/12 for the Docker bridge network).
+ADMIN_ALLOWED_IPS=127.0.0.1,::1
+
+# Comma-separated IP/CIDR list of trusted reverse proxies.
+# X-Forwarded-For is honored ONLY when the direct TCP peer is in this list;
+# any other peer's X-Forwarded-For is ignored (spoofing protection).
+# Behind a reverse proxy, set this to the proxy's address.
+ADMIN_TRUSTED_PROXIES=127.0.0.1,::1
 
 # HMAC secret for signing admin session cookies.
 # Auto-generated if not set (sessions lost on restart).
 ADMIN_SESSION_SECRET=
+
+# Mark the admin session cookie Secure (never sent over plain HTTP).
+# Defaults to 1 outside dev mode; set to 0 for plain-HTTP local development.
+# ADMIN_COOKIE_SECURE=1

--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,9 @@
+# GitGuardian secret-scanning configuration.
+#
+# The files below are test fixtures that deliberately contain FAKE credentials
+# (a dummy login password and a bcrypt hash generated at test time). They are
+# not real secrets — they exist only to exercise the admin auth flows. Ignore
+# them so the "Username Password" / "Generic Password" detectors don't fail CI.
+paths_ignore:
+  - tests/api/test_admin.py
+  - tests/unit/test_admin_auth.py

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ scripts/benchmark_llm.py
 
 # Transfer logs produced by scripts/upload_cache.sh
 /upload-cache-*.log
+
+# Local agent tooling state (worktrees, session data)
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,9 @@ Environment variables are loaded from `.env` via `python-dotenv` (see `.env.exam
 - `ADMIN_USERNAME` — admin dashboard login username (default: `admin`)
 - `ADMIN_PASSWORD_HASH` — bcrypt hash of the admin password (default: empty — login rejects all)
 - `ADMIN_SESSION_SECRET` — HMAC secret for signing admin session cookies (default: auto-generated)
-- `ADMIN_ALLOWED_IPS` — comma-separated IP/CIDR whitelist for admin access (default: `127.0.0.1,::1,172.16.0.0/12`)
+- `ADMIN_ALLOWED_IPS` — comma-separated IP/CIDR whitelist for admin access (default: `127.0.0.1,::1` — loopback only; the old default included `172.16.0.0/12`)
+- `ADMIN_TRUSTED_PROXIES` — comma-separated IP/CIDR of reverse proxies whose `X-Forwarded-For` is trusted to identify the client (default: `127.0.0.1,::1`; XFF from any other peer is ignored)
+- `ADMIN_COOKIE_SECURE` — send the admin session cookie only over HTTPS (default: `1` outside dev mode)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ All configuration is via environment variables. Copy `.env.example` to `.env` fo
 | `ADMIN_USERNAME`          | `admin`                       | Admin dashboard login username                                 |
 | `ADMIN_PASSWORD_HASH`     | _(empty)_                     | bcrypt hash of the admin password                              |
 | `ADMIN_SESSION_SECRET`    | _(auto-generated)_            | HMAC secret for signing admin session cookies                  |
-| `ADMIN_ALLOWED_IPS`       | `127.0.0.1,::1,172.16.0.0/12`| IP/CIDR whitelist for admin access                             |
+| `ADMIN_ALLOWED_IPS`       | `127.0.0.1,::1`               | IP/CIDR whitelist for admin access                             |
+| `ADMIN_TRUSTED_PROXIES`   | `127.0.0.1,::1`               | Proxies whose `X-Forwarded-For` may identify the real client   |
+| `ADMIN_COOKIE_SECURE`     | `1` (off in dev mode)         | Send the admin session cookie only over HTTPS                  |
+| `ADMIN_BIND_ADDR`         | `127.0.0.1`                   | Docker only: host address the admin port is bound to           |
 
 ## Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,11 @@ services:
   backend:
     build: .
     command: ["python", "-m", "pspcz_analyzer.main_backend"]
+    # Loopback-only by default: the admin panel is not meant to be public.
+    # Behind a reverse proxy or for LAN access, set ADMIN_BIND_ADDR (e.g. 0.0.0.0)
+    # and lock admin access down with ADMIN_ALLOWED_IPS / ADMIN_TRUSTED_PROXIES.
     ports:
-      - "${ADMIN_PORT:-8001}:${ADMIN_PORT:-8001}"
+      - "${ADMIN_BIND_ADDR:-127.0.0.1}:${ADMIN_PORT:-8001}:${ADMIN_PORT:-8001}"
     volumes:
       - ${PSPCZ_CACHE_HOST_DIR:-./cache-data}:/data/cache:z
     env_file:

--- a/pspcz_analyzer/admin/auth.py
+++ b/pspcz_analyzer/admin/auth.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import hmac
-import ipaddress
 import secrets
 import time
 from typing import Any
@@ -17,55 +16,32 @@ from pspcz_analyzer.config import (
     ADMIN_ALLOWED_IPS,
     ADMIN_PASSWORD_HASH,
     ADMIN_SESSION_SECRET,
+    ADMIN_TRUSTED_PROXIES,
 )
+from pspcz_analyzer.middleware import is_same_origin
+from pspcz_analyzer.proxy import extract_client_ip, is_ip_allowed, parse_ip_networks
 
 _SESSION_COOKIE = "pspcz_admin_session"
 _SESSION_TTL = 86400  # 24 hours
 
+# HTTP methods that need no CSRF origin check (safe, side-effect-free).
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
 # Auto-generate secret if not provided (ephemeral — sessions lost on restart)
 _session_secret = ADMIN_SESSION_SECRET or secrets.token_hex(32)
 
-
-def _parse_ip_whitelist(raw: str) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
-    """Parse comma-separated IP/CIDR whitelist into network objects."""
-    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
-    for entry in raw.split(","):
-        entry = entry.strip()
-        if not entry:
-            continue
-        try:
-            networks.append(ipaddress.ip_network(entry, strict=False))
-        except ValueError:
-            logger.warning("[admin-auth] Invalid IP/CIDR in whitelist: {}", entry)
-    return networks
-
-
-_allowed_networks = _parse_ip_whitelist(ADMIN_ALLOWED_IPS)
+_allowed_networks = parse_ip_networks(ADMIN_ALLOWED_IPS)
+_trusted_proxies = parse_ip_networks(ADMIN_TRUSTED_PROXIES)
 
 
 def _client_ip(request: Request) -> str:
-    """Extract client IP from request, respecting X-Forwarded-For behind proxies."""
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    client = request.client
-    return client.host if client else "0.0.0.0"
+    """Extract the real client IP, trusting X-Forwarded-For only from known proxies."""
+    return extract_client_ip(request, _trusted_proxies)
 
 
 def _is_ip_allowed(ip_str: str) -> bool:
-    """Check if client IP is in the allowed networks.
-
-    Handles IPv4-mapped IPv6 addresses (e.g. ::ffff:192.168.1.1)
-    by normalizing them to plain IPv4 before matching.
-    """
-    try:
-        addr = ipaddress.ip_address(ip_str)
-    except ValueError:
-        return False
-    # Normalize IPv4-mapped IPv6 (::ffff:x.x.x.x) to plain IPv4
-    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
-        addr = addr.ipv4_mapped
-    return any(addr in net for net in _allowed_networks)
+    """Check if client IP is in the allowed networks."""
+    return is_ip_allowed(ip_str, _allowed_networks)
 
 
 def _sign_session(username: str, expires: int) -> str:
@@ -127,9 +103,9 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
         """Check IP whitelist, then session, redirect to login if needed."""
         path = request.url.path
 
-        # Allow login page, static assets, and the health endpoint without a
-        # session (still IP-whitelisted) — docker healthchecks need it.
-        if path in ("/admin/login", "/admin/static", "/admin/api/health"):
+        # Allow the login page and the health endpoint without a session
+        # (still IP-whitelisted) — docker healthchecks need the latter.
+        if path in ("/admin/login", "/admin/api/health"):
             return await self._check_ip_then_proceed(request, call_next)
 
         return await self._check_ip_then_proceed(request, call_next, require_session=True)
@@ -141,7 +117,7 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
         *,
         require_session: bool = False,
     ) -> Response:
-        """Verify IP whitelist, optionally check session."""
+        """Verify IP whitelist and CSRF origin, optionally check session."""
         ip = _client_ip(request)
         if not _is_ip_allowed(ip):
             xff = request.headers.get("x-forwarded-for", "(none)")
@@ -151,6 +127,18 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
                 ip,
                 xff,
                 client_host,
+            )
+            return Response("Forbidden", status_code=403)
+
+        # CSRF: state-changing requests must originate from our own origin.
+        # SameSite=Lax cookies remain a backstop; this blocks cross-origin
+        # form posts outright (e.g. a malicious site triggering a pipeline).
+        if request.method not in _SAFE_METHODS and not is_same_origin(request):
+            logger.warning(
+                "[admin-auth] Blocked cross-origin {} {} from IP={}",
+                request.method,
+                request.url.path,
+                ip,
             )
             return Response("Forbidden", status_code=403)
 

--- a/pspcz_analyzer/admin/routes.py
+++ b/pspcz_analyzer/admin/routes.py
@@ -18,7 +18,7 @@ from pspcz_analyzer.admin.auth import (
 )
 from pspcz_analyzer.admin.log_stream import log_broadcaster
 from pspcz_analyzer.admin.pipeline_history import PipelineHistory
-from pspcz_analyzer.config import ADMIN_USERNAME, DEFAULT_CACHE_DIR
+from pspcz_analyzer.config import ADMIN_COOKIE_SECURE, ADMIN_USERNAME, DEFAULT_CACHE_DIR
 from pspcz_analyzer.models.pipeline_progress import (
     AmendmentMode,
     PipelineStage,
@@ -139,13 +139,14 @@ async def login_submit(
         create_session_cookie(username),
         httponly=True,
         samesite="lax",
+        secure=ADMIN_COOKIE_SECURE,
         max_age=86400,
     )
     return response
 
 
 @router.post("/logout")
-async def logout(request: Request) -> RedirectResponse:
+async def logout() -> RedirectResponse:
     """Clear admin session."""
     response = RedirectResponse(url="/admin/login", status_code=303)
     response.delete_cookie(_SESSION_COOKIE)
@@ -433,7 +434,7 @@ async def pipeline_history_endpoint(request: Request) -> list[dict]:
 
 
 @router.get("/api/pipeline/logs")
-async def pipeline_logs_sse(request: Request) -> StreamingResponse:
+async def pipeline_logs_sse() -> StreamingResponse:
     """SSE endpoint for real-time pipeline log streaming."""
     return StreamingResponse(
         log_broadcaster.subscribe(),

--- a/pspcz_analyzer/config.py
+++ b/pspcz_analyzer/config.py
@@ -188,6 +188,17 @@ GITHUB_FEEDBACK_LABELS = os.environ.get("GITHUB_FEEDBACK_LABELS", "user-feedback
 # Admin dashboard — backend-only authentication and access control
 ADMIN_USERNAME = os.environ.get("ADMIN_USERNAME", "admin")
 ADMIN_PASSWORD_HASH = os.environ.get("ADMIN_PASSWORD_HASH", "")
-ADMIN_ALLOWED_IPS = os.environ.get("ADMIN_ALLOWED_IPS", "127.0.0.1,::1,172.16.0.0/12")
+# Loopback only by default. The old default included 172.16.0.0/12, which
+# admitted every Docker-bridge container and LAN host in that range to the
+# login page — add the needed CIDR back explicitly if your deployment needs it.
+ADMIN_ALLOWED_IPS = os.environ.get("ADMIN_ALLOWED_IPS", "127.0.0.1,::1")
+# Proxies whose X-Forwarded-For header may be trusted to identify the real
+# client IP. Requests from any other peer ignore X-Forwarded-For entirely
+# (otherwise a remote attacker could spoof "127.0.0.1" and pass the whitelist).
+# Behind a reverse proxy, set this to the proxy's IP/CIDR.
+ADMIN_TRUSTED_PROXIES = os.environ.get("ADMIN_TRUSTED_PROXIES", "127.0.0.1,::1")
 ADMIN_SESSION_SECRET = os.environ.get("ADMIN_SESSION_SECRET", "")
 ADMIN_PORT = int(os.environ.get("ADMIN_PORT", "8001"))
+# Mark the session cookie Secure so it is never sent over plain HTTP.
+# Defaults off in dev mode (plain-HTTP localhost), on everywhere else.
+ADMIN_COOKIE_SECURE = os.environ.get("ADMIN_COOKIE_SECURE", "0" if DEV else "1") == "1"

--- a/pspcz_analyzer/middleware.py
+++ b/pspcz_analyzer/middleware.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import HTTPException
 from loguru import logger
@@ -14,6 +15,32 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 _compute_pool = ThreadPoolExecutor(max_workers=2)
+
+
+def is_same_origin(request: Request) -> bool:
+    """Check that the request's Origin or Referer matches its own host.
+
+    Used as CSRF protection for state-changing endpoints: browsers send
+    Origin (or Referer) on cross-origin form posts, and a mismatch means
+    the request was triggered by a foreign site.
+
+    Args:
+        request: Incoming request.
+
+    Returns:
+        True if Origin or Referer parses to the same hostname as the
+        request URL. False when both headers are missing or unparseable
+        (fail closed).
+    """
+    expected = request.url.hostname
+    for header in ("origin", "referer"):
+        value = request.headers.get(header)
+        if value:
+            try:
+                return urlparse(value).hostname == expected
+            except ValueError:
+                return False
+    return False
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):

--- a/pspcz_analyzer/proxy.py
+++ b/pspcz_analyzer/proxy.py
@@ -1,0 +1,117 @@
+"""Client-IP extraction and IP whitelist logic, proxy-aware.
+
+The admin dashboard gates access on an IP whitelist. When the app runs
+behind a reverse proxy the real client IP arrives in ``X-Forwarded-For``,
+but that header is attacker-controlled unless the direct TCP peer is a
+known, trusted proxy. Trusting it unconditionally lets any remote client
+send ``X-Forwarded-For: 127.0.0.1`` and pass a loopback whitelist.
+
+:func:`extract_client_ip` implements the rightmost-untrusted algorithm:
+X-Forwarded-For is consulted only when the TCP peer itself is trusted,
+and the client IP is the first (rightmost) entry that is NOT a trusted
+proxy. Everything else falls back to the TCP peer.
+"""
+
+import ipaddress
+from collections.abc import Sequence
+
+from loguru import logger
+from starlette.requests import Request
+
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+def parse_ip_networks(raw: str) -> list[IPNetwork]:
+    """Parse a comma-separated list of IP/CIDR entries into network objects.
+
+    Invalid entries are logged and skipped rather than raising, so one
+    typo in the env var does not lock the admin out entirely.
+
+    Args:
+        raw: Comma-separated IP addresses or CIDR networks.
+
+    Returns:
+        Parsed networks, in input order.
+    """
+    networks: list[IPNetwork] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            logger.warning("[proxy] Invalid IP/CIDR entry ignored: {}", entry)
+    return networks
+
+
+def _parse_address(ip_str: str) -> IPAddress | None:
+    """Parse an IP string, normalizing IPv4-mapped IPv6 to plain IPv4.
+
+    Args:
+        ip_str: IP address literal (possibly ``::ffff:x.x.x.x`` form).
+
+    Returns:
+        The parsed address, or None if unparseable.
+    """
+    try:
+        addr: IPAddress = ipaddress.ip_address(ip_str.strip())
+    except ValueError:
+        return None
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+        return addr.ipv4_mapped
+    return addr
+
+
+def is_ip_allowed(ip_str: str, networks: Sequence[IPNetwork]) -> bool:
+    """Check whether an IP literal falls within any of the given networks.
+
+    Args:
+        ip_str: IP address literal.
+        networks: Allowed networks to match against.
+
+    Returns:
+        True if the IP is in at least one network, False otherwise
+        (including unparseable input).
+    """
+    addr = _parse_address(ip_str)
+    if addr is None:
+        return False
+    return any(addr in net for net in networks)
+
+
+def extract_client_ip(request: Request, trusted_proxies: Sequence[IPNetwork]) -> str:
+    """Determine the real client IP for a request, respecting proxies safely.
+
+    X-Forwarded-For is only trusted when the direct TCP peer is itself a
+    trusted proxy; otherwise an attacker could spoof the header. When the
+    peer is trusted, the chain is walked right-to-left and the first
+    untrusted entry (the one the trusted proxy appended) is returned.
+
+    Args:
+        request: Incoming request.
+        trusted_proxies: Networks whose X-Forwarded-For headers may be
+            trusted (typically loopback and/or the reverse proxy's IP).
+
+    Returns:
+        The client IP string. Falls back to the TCP peer (or ``0.0.0.0``
+        if unknown) whenever the header is absent or fully trusted.
+    """
+    client = request.client
+    peer = client.host if client else "0.0.0.0"
+
+    if not is_ip_allowed(peer, trusted_proxies):
+        # Untrusted peer: any X-Forwarded-For is attacker-controlled.
+        return peer
+
+    forwarded = request.headers.get("x-forwarded-for", "")
+    entries = [entry.strip() for entry in forwarded.split(",") if entry.strip()]
+    if not entries:
+        return peer
+
+    for entry in reversed(entries):
+        if not is_ip_allowed(entry, trusted_proxies):
+            return entry
+    # Every entry is a trusted proxy — return the leftmost as best effort.
+    return entries[0]

--- a/pspcz_analyzer/routes/feedback.py
+++ b/pspcz_analyzer/routes/feedback.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from pathlib import Path
-from urllib.parse import urlparse
 
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
@@ -10,24 +9,12 @@ from fastapi.templating import Jinja2Templates
 
 from pspcz_analyzer.config import GITHUB_FEEDBACK_ENABLED
 from pspcz_analyzer.i18n import gettext as _t
+from pspcz_analyzer.middleware import is_same_origin
 from pspcz_analyzer.rate_limit import limiter
 from pspcz_analyzer.services.feedback_service import GitHubFeedbackClient
 
 router = APIRouter(tags=["Feedback"])
 templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
-
-
-def _validate_origin(request: Request) -> bool:
-    """Check that Origin or Referer matches the request host."""
-    expected = request.url.hostname
-    for header in ("origin", "referer"):
-        value = request.headers.get(header)
-        if value:
-            try:
-                return urlparse(value).hostname == expected
-            except ValueError:
-                return False
-    return False
 
 
 def _validate_feedback_fields(title: str, body: str) -> str | None:
@@ -50,7 +37,7 @@ async def feedback_api(
     lang = getattr(request.state, "lang", "cs")
     suffix = ""
 
-    if not _validate_origin(request):
+    if not is_same_origin(request):
         return templates.TemplateResponse(
             "partials/feedback_result.html",
             {

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1,0 +1,202 @@
+"""End-to-end tests for admin auth: IP whitelist, XFF spoofing, login, CSRF, masking."""
+
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+from starlette.types import Receive, Scope, Send
+
+from pspcz_analyzer.admin import auth, routes
+from pspcz_analyzer.main_backend import app as backend_app
+from pspcz_analyzer.proxy import parse_ip_networks
+
+LOOPBACK = "127.0.0.1"
+ATTACKER = "203.0.113.7"
+ORIGIN = {"Origin": "http://testserver"}
+
+
+@pytest.fixture()
+def admin_app(mock_data_service, tmp_path):
+    """Backend app with a mocked DataService rooted at a temp cache dir."""
+    mock_data_service.cache_dir = tmp_path
+
+    @asynccontextmanager
+    async def _test_lifespan(app):
+        app.state.data = mock_data_service
+        app.state.pipeline_history = MagicMock()
+        yield
+
+    backend_app.router.lifespan_context = _test_lifespan
+    return backend_app
+
+
+@pytest.fixture()
+def make_client(admin_app):
+    """Factory: TestClient whose requests arrive from a chosen client IP.
+
+    Each client enters its context so the (mocked) lifespan runs and
+    ``app.state.data`` is populated before any request is handled.
+    """
+    entered: list[TestClient] = []
+
+    def _factory(client_ip: str) -> TestClient:
+        async def _ip_pinning_app(scope: Scope, receive: Receive, send: Send) -> None:
+            if scope["type"] == "http":
+                scope = dict(scope, client=(client_ip, 0))
+            await admin_app(scope, receive, send)
+
+        test_client = TestClient(_ip_pinning_app)
+        test_client.__enter__()
+        entered.append(test_client)
+        return test_client
+
+    yield _factory
+    for test_client in entered:
+        test_client.__exit__(None, None, None)
+
+
+@pytest.fixture()
+def client(make_client):
+    """TestClient arriving from loopback (whitelisted by default)."""
+    return make_client(LOOPBACK)
+
+
+@pytest.fixture()
+def session_cookie():
+    """A valid signed admin session cookie value."""
+    return {auth._SESSION_COOKIE: auth.create_session_cookie("admin")}
+
+
+@pytest.fixture()
+def admin_password(monkeypatch):
+    """Configure a known admin password for login tests (side-effect fixture)."""
+    hashed = bcrypt.hashpw(b"s3cret", bcrypt.gensalt()).decode()
+    monkeypatch.setattr(auth, "ADMIN_PASSWORD_HASH", hashed)
+    monkeypatch.setattr(routes, "ADMIN_USERNAME", "admin")
+    monkeypatch.setattr(routes, "ADMIN_COOKIE_SECURE", True)
+    return "s3cret"
+
+
+# ── IP whitelist ─────────────────────────────────────────────────
+
+
+def test_health_allowed_from_loopback(client):
+    assert client.get("/admin/api/health").status_code == 200
+
+
+def test_health_blocked_from_foreign_ip(make_client):
+    assert make_client(ATTACKER).get("/admin/api/health").status_code == 403
+
+
+def test_xff_spoof_from_untrusted_peer_rejected(make_client):
+    """The acceptance test for the XFF bypass: spoofed loopback must not help."""
+    attacker = make_client(ATTACKER)
+    response = attacker.get("/admin/api/health", headers={"X-Forwarded-For": LOOPBACK})
+    assert response.status_code == 403
+
+
+def test_xff_honored_from_trusted_proxy(make_client, monkeypatch):
+    monkeypatch.setattr(auth, "_trusted_proxies", parse_ip_networks("203.0.113.0/24"))
+    proxy_client = make_client(ATTACKER)  # peer now trusted as a proxy
+    # Real client behind the proxy is loopback → allowed.
+    ok = proxy_client.get("/admin/api/health", headers={"X-Forwarded-For": LOOPBACK})
+    assert ok.status_code == 200
+    # Real client behind the proxy is NOT whitelisted → blocked.
+    blocked = proxy_client.get("/admin/api/health", headers={"X-Forwarded-For": "198.51.100.9"})
+    assert blocked.status_code == 403
+
+
+# ── Login + session ──────────────────────────────────────────────
+
+
+def test_login_wrong_password_returns_401(client, request: pytest.FixtureRequest):
+    request.getfixturevalue("admin_password")  # applies the password side effect
+    response = client.post(
+        "/admin/login",
+        data={"username": "admin", "password": "wrong"},
+        headers=ORIGIN,
+    )
+    assert response.status_code == 401
+
+
+def test_login_success_sets_secure_cookie(client, admin_password):
+    response = client.post(
+        "/admin/login",
+        data={"username": "admin", "password": admin_password},
+        headers=ORIGIN,
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    set_cookie = response.headers["set-cookie"]
+    assert "HttpOnly" in set_cookie
+    assert "samesite=lax" in set_cookie.lower()
+    assert "Secure" in set_cookie
+
+    # Cookie grants access to the dashboard.
+    dashboard = client.get("/admin/")
+    assert dashboard.status_code == 200
+
+
+def test_dashboard_requires_session(client):
+    response = client.get("/admin/", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/admin/login"
+
+
+def test_tampered_session_cookie_rejected(client):
+    client.cookies.set(auth._SESSION_COOKIE, "admin:9999999999:" + "0" * 64)
+    response = client.get("/admin/", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/admin/login"
+
+
+# ── CSRF protection ──────────────────────────────────────────────
+
+
+def test_login_blocked_without_origin(client, request: pytest.FixtureRequest):
+    request.getfixturevalue("admin_password")
+    response = client.post("/admin/login", data={"username": "admin", "password": "s3cret"})
+    assert response.status_code == 403
+
+
+def test_login_blocked_with_foreign_origin(client, request: pytest.FixtureRequest):
+    request.getfixturevalue("admin_password")
+    response = client.post(
+        "/admin/login",
+        data={"username": "admin", "password": "s3cret"},
+        headers={"Origin": "http://evil.example"},
+    )
+    assert response.status_code == 403
+
+
+def test_logout_blocked_cross_origin(client, session_cookie):
+    client.cookies.set(auth._SESSION_COOKIE, session_cookie[auth._SESSION_COOKIE])
+    response = client.post("/admin/logout", headers={"Origin": "http://evil.example"})
+    assert response.status_code == 403
+
+
+def test_logout_allowed_same_origin(client, session_cookie):
+    client.cookies.set(auth._SESSION_COOKIE, session_cookie[auth._SESSION_COOKIE])
+    response = client.post("/admin/logout", headers=ORIGIN, follow_redirects=False)
+    assert response.status_code == 303
+
+
+# ── Config editor secret masking ─────────────────────────────────
+
+
+def test_config_endpoint_masks_secrets(client, session_cookie, mock_data_service):
+    secret = "super-secret-api-key-123"
+    config_path = mock_data_service.cache_dir / "runtime_config.json"
+    config_path.write_text(
+        json.dumps({"openai_api_key": secret, "llm_provider": "openai"}), encoding="utf-8"
+    )
+    client.cookies.set(auth._SESSION_COOKIE, session_cookie[auth._SESSION_COOKIE])
+
+    response = client.get("/admin/api/config")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["openai_api_key"] == "***"
+    assert secret not in response.text

--- a/tests/unit/test_admin_auth.py
+++ b/tests/unit/test_admin_auth.py
@@ -1,0 +1,186 @@
+"""Unit tests for admin auth: proxy-aware client IP, whitelist, sessions, CSRF."""
+
+import bcrypt
+import pytest
+from starlette.requests import Request
+
+from pspcz_analyzer.admin import auth
+from pspcz_analyzer.middleware import is_same_origin
+from pspcz_analyzer.proxy import extract_client_ip, is_ip_allowed, parse_ip_networks
+
+
+def _make_request(
+    client_host: str | None = "1.2.3.4",
+    headers: dict[str, str] | None = None,
+    method: str = "GET",
+    host: str = "example.com",
+) -> Request:
+    """Build a minimal Starlette Request with controlled client and headers."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": method,
+        "scheme": "http",
+        "path": "/admin/",
+        "headers": raw_headers,
+        "server": (host, 80),
+        "client": (client_host, 12345) if client_host else None,
+    }
+    return Request(scope)
+
+
+# ── parse_ip_networks / is_ip_allowed ────────────────────────────
+
+
+class TestParseIpNetworks:
+    def test_parses_cidrs_and_addresses(self):
+        nets = parse_ip_networks("127.0.0.1, ::1, 10.0.0.0/8")
+        assert len(nets) == 3
+
+    def test_skips_invalid_entries_with_warning(self):
+        nets = parse_ip_networks("127.0.0.1, not-an-ip, 999.999.1.1")
+        assert len(nets) == 1
+
+    def test_empty_and_whitespace(self):
+        assert parse_ip_networks("") == []
+        assert parse_ip_networks(" , ,") == []
+
+
+class TestIsIpAllowed:
+    def test_in_network(self):
+        nets = parse_ip_networks("127.0.0.1, 10.0.0.0/8")
+        assert is_ip_allowed("127.0.0.1", nets)
+        assert is_ip_allowed("10.1.2.3", nets)
+
+    def test_out_of_network(self):
+        nets = parse_ip_networks("127.0.0.1")
+        assert not is_ip_allowed("203.0.113.7", nets)
+
+    def test_ipv4_mapped_ipv6_normalized(self):
+        nets = parse_ip_networks("192.168.1.0/24")
+        assert is_ip_allowed("::ffff:192.168.1.10", nets)
+
+    def test_unparseable_input_rejected(self):
+        nets = parse_ip_networks("0.0.0.0/0")
+        assert not is_ip_allowed("garbage", nets)
+        assert not is_ip_allowed("", nets)
+
+
+# ── extract_client_ip (the XFF spoofing regression) ──────────────
+
+
+class TestExtractClientIp:
+    def test_no_xff_returns_tcp_peer(self):
+        request = _make_request(client_host="203.0.113.7")
+        assert extract_client_ip(request, parse_ip_networks("127.0.0.1")) == "203.0.113.7"
+
+    def test_xff_ignored_when_peer_untrusted(self):
+        """The core vulnerability: spoofing XFF from the open internet must not help."""
+        request = _make_request(client_host="203.0.113.7", headers={"x-forwarded-for": "127.0.0.1"})
+        assert extract_client_ip(request, parse_ip_networks("127.0.0.1")) == "203.0.113.7"
+
+    def test_rightmost_untrusted_entry_from_trusted_proxy(self):
+        request = _make_request(
+            client_host="127.0.0.1",
+            headers={"x-forwarded-for": "198.51.100.9, 10.0.0.1"},
+        )
+        trusted = parse_ip_networks("127.0.0.1, 10.0.0.0/8")
+        # 10.0.0.1 is trusted (the proxy); 198.51.100.9 is the real client.
+        assert extract_client_ip(request, trusted) == "198.51.100.9"
+
+    def test_all_trusted_chain_returns_leftmost(self):
+        request = _make_request(
+            client_host="127.0.0.1", headers={"x-forwarded-for": "10.0.0.2, 10.0.0.1"}
+        )
+        trusted = parse_ip_networks("127.0.0.1, 10.0.0.0/8")
+        assert extract_client_ip(request, trusted) == "10.0.0.2"
+
+    def test_trusted_peer_without_xff_returns_peer(self):
+        request = _make_request(client_host="127.0.0.1")
+        assert extract_client_ip(request, parse_ip_networks("127.0.0.1")) == "127.0.0.1"
+
+    def test_unparseable_xff_entry_treated_as_client(self):
+        # A garbage entry from a trusted proxy is returned as-is; the whitelist
+        # check then rejects it (fail closed) rather than skipping to a real IP.
+        request = _make_request(client_host="127.0.0.1", headers={"x-forwarded-for": "bogus"})
+        assert extract_client_ip(request, parse_ip_networks("127.0.0.1")) == "bogus"
+
+    def test_missing_client_falls_back(self):
+        request = _make_request(client_host=None)
+        assert extract_client_ip(request, parse_ip_networks("127.0.0.1")) == "0.0.0.0"
+
+
+# ── Session signing / verification ───────────────────────────────
+
+
+class TestSessions:
+    def test_sign_verify_roundtrip(self):
+        token = auth.create_session_cookie("admin")
+        assert auth._verify_session(token) == "admin"
+
+    def test_tampered_signature_rejected(self):
+        token = auth.create_session_cookie("admin")
+        username, expires, _sig = token.split(":")
+        assert auth._verify_session(f"{username}:{expires}:" + "0" * 64) is None
+
+    def test_expired_token_rejected(self, monkeypatch):
+        now = [1_000_000.0]
+        monkeypatch.setattr(auth.time, "time", lambda: now[0])
+        token = auth.create_session_cookie("admin")  # expires = now + TTL
+        now[0] += auth._SESSION_TTL + 1
+        assert auth._verify_session(token) is None
+
+    def test_malformed_tokens_rejected(self):
+        assert auth._verify_session("onlyonepart") is None
+        assert auth._verify_session("a:b") is None
+        assert auth._verify_session("a:b:c:d") is None
+        assert auth._verify_session("admin:notanumber:abcd") is None
+
+
+class TestVerifyPassword:
+    def test_empty_hash_rejects_everything(self, monkeypatch):
+        monkeypatch.setattr(auth, "ADMIN_PASSWORD_HASH", "")
+        assert not auth.verify_password("anything")
+        assert not auth.verify_password("")
+
+    def test_correct_password_accepted(self, monkeypatch):
+        hashed = bcrypt.hashpw(b"s3cret", bcrypt.gensalt()).decode()
+        monkeypatch.setattr(auth, "ADMIN_PASSWORD_HASH", hashed)
+        assert auth.verify_password("s3cret")
+
+    def test_wrong_password_rejected(self, monkeypatch):
+        hashed = bcrypt.hashpw(b"s3cret", bcrypt.gensalt()).decode()
+        monkeypatch.setattr(auth, "ADMIN_PASSWORD_HASH", hashed)
+        assert not auth.verify_password("wrong")
+
+
+# ── is_same_origin (CSRF helper) ─────────────────────────────────
+
+
+class TestIsSameOrigin:
+    def test_matching_origin(self):
+        request = _make_request(headers={"origin": "http://example.com/admin"})
+        assert is_same_origin(request)
+
+    def test_matching_referer(self):
+        request = _make_request(headers={"referer": "http://example.com/votes"})
+        assert is_same_origin(request)
+
+    def test_foreign_origin_rejected(self):
+        request = _make_request(headers={"origin": "http://evil.com"})
+        assert not is_same_origin(request)
+
+    def test_missing_headers_fail_closed(self):
+        assert not is_same_origin(_make_request())
+
+    def test_origin_checked_before_referer(self):
+        request = _make_request(
+            headers={"origin": "http://evil.com", "referer": "http://example.com/"}
+        )
+        assert not is_same_origin(request)
+
+
+@pytest.mark.parametrize("header_value", [":://bad", "http://"])
+def test_is_same_origin_unparseable_values_fail_closed(header_value):
+    request = _make_request(headers={"origin": header_value})
+    assert not is_same_origin(request)


### PR DESCRIPTION
## What

Fixes two high-severity findings from the repo audit:

**S1 — `X-Forwarded-For` whitelist bypass (HIGH).** `_client_ip()` in `admin/auth.py` trusted `X-Forwarded-For` unconditionally, and the admin port is published on `0.0.0.0` (`docker-compose.yml`). Any remote attacker could send `X-Forwarded-For: 127.0.0.1` and pass the IP whitelist — reducing "IP whitelist + bcrypt" to just "bcrypt".

**S3 — session cookie hardening.** The admin session cookie lacked `Secure`, and `/admin` state-changing endpoints had no CSRF origin check (SameSite=Lax was the only backstop).

## How

- **New `pspcz_analyzer/proxy.py`** — single source of truth for client-IP logic: `parse_ip_networks()`, `is_ip_allowed()` (moved from `auth.py`, keeps IPv4-mapped-IPv6 normalization), and `extract_client_ip()`, which implements the correct **rightmost-untrusted** algorithm:
  - untrusted TCP peer → return the peer, ignore `X-Forwarded-For` entirely (attacker-controlled);
  - trusted peer (in `ADMIN_TRUSTED_PROXIES`) → walk the XFF chain right→left, return the first untrusted entry.
- **Middleware-level trusted proxies, not uvicorn `--proxy-headers`** — uvicorn rewrites `request.client` globally for *both* processes, which would silently make the frontend's slowapi rate-limit keys XFF-spoofable. Middleware config is per-process and changes nothing for existing deployments.
- **CSRF:** `is_same_origin()` extracted from the feedback route into `middleware.py`; `AdminAuthMiddleware` now enforces it on all non-safe `/admin` methods; `routes/feedback.py` reuses the shared helper.
- **Cookie:** `secure=ADMIN_COOKIE_SECURE` on the session cookie (defaults to `1` outside dev mode).
- Dead `/admin/static` public path removed (verified: no StaticFiles mount, no template refs).

## ⚠️ Behavior changes (migration notes)

| Change | Impact | Action |
| --- | --- | --- |
| `ADMIN_ALLOWED_IPS` default → `127.0.0.1,::1` | Drops `172.16.0.0/12`, which admitted every Docker-bridge container. Compose healthchecks use in-container loopback, so nothing breaks. | Re-add the CIDR explicitly if you relied on bridge-network access. |
| Admin port binds to `${ADMIN_BIND_ADDR:-127.0.0.1}` in compose | No longer exposed on `0.0.0.0` by default. | Set `ADMIN_BIND_ADDR=0.0.0.0` to restore the old behavior (behind a proxy, set `ADMIN_TRUSTED_PROXIES` to the proxy's address). |
| Session cookie `Secure` in prod | Cookie not sent over plain HTTP. | Set `ADMIN_COOKIE_SECURE=0` for plain-HTTP setups. |

New env vars: `ADMIN_TRUSTED_PROXIES` (default `127.0.0.1,::1`), `ADMIN_COOKIE_SECURE`, `ADMIN_BIND_ADDR` — documented in README, `.env.example`, `CLAUDE.md`.

## Tests — 41 new

- `tests/unit/test_admin_auth.py` — network parsing/matching, mapped-IPv6, rightmost-untrusted chain, **XFF-ignored-when-peer-untrusted (the regression)**, session sign/verify/tamper/expiry, empty-hash-rejects-all, `is_same_origin`.
- `tests/api/test_admin.py` — backend TestClient with ASGI-scope client-tuple pinning: whitelist 403s, **end-to-end XFF spoof → 403**, trusted-proxy honored, login flows + cookie flags (`HttpOnly`/`SameSite=Lax`/`Secure`), cross-origin POST → 403, config-editor secret masking (previously zero coverage).

The acceptance test (`X-Forwarded-For: 127.0.0.1` from an untrusted peer → 403) **fails on `main`** — the old code returned `forwarded.split(",")[0]` unconditionally — and passes here.

## Verification

- `ruff format` + `ruff check --fix` — clean
- `pytest -m "not integration" --cov -q` — **507 passed, 26 deselected, coverage 56.25%** (baseline 466 / 51.13%)
- `pyright` — 0 errors, 0 warnings

Part of the audit remediation series (follows #60, #61). Next: backend rate limiting (S2), which builds on `proxy.extract_client_ip`.