### PR TITLE
feat(security): rate-limit the admin backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,3 +155,10 @@ ADMIN_SESSION_SECRET=
 # Mark the admin session cookie Secure (never sent over plain HTTP).
 # Defaults to 1 outside dev mode; set to 0 for plain-HTTP local development.
 # ADMIN_COOKIE_SECURE=1
+
+# --- Rate limiting ---
+# Comma-separated IP/CIDR list of trusted reverse proxies for rate-limit
+# bucketing. Empty by default: buckets key on the TCP peer (spoof-proof).
+# Behind a reverse proxy, set this to the proxy's address — otherwise every
+# visitor shares one bucket and limits trip for all of them.
+RATE_LIMIT_TRUSTED_PROXIES=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Environment variables are loaded from `.env` via `python-dotenv` (see `.env.exam
 - `ADMIN_ALLOWED_IPS` — comma-separated IP/CIDR whitelist for admin access (default: `127.0.0.1,::1` — loopback only; the old default included `172.16.0.0/12`)
 - `ADMIN_TRUSTED_PROXIES` — comma-separated IP/CIDR of reverse proxies whose `X-Forwarded-For` is trusted to identify the client (default: `127.0.0.1,::1`; XFF from any other peer is ignored)
 - `ADMIN_COOKIE_SECURE` — send the admin session cookie only over HTTPS (default: `1` outside dev mode)
+- `RATE_LIMIT_TRUSTED_PROXIES` — comma-separated IP/CIDR of proxies whose `X-Forwarded-For` may key rate-limit buckets (default: empty — buckets key on the TCP peer, spoof-proof; set to the proxy's address behind a reverse proxy)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ All configuration is via environment variables. Copy `.env.example` to `.env` fo
 | `ADMIN_TRUSTED_PROXIES`   | `127.0.0.1,::1`               | Proxies whose `X-Forwarded-For` may identify the real client   |
 | `ADMIN_COOKIE_SECURE`     | `1` (off in dev mode)         | Send the admin session cookie only over HTTPS                  |
 | `ADMIN_BIND_ADDR`         | `127.0.0.1`                   | Docker only: host address the admin port is bound to           |
+| `RATE_LIMIT_TRUSTED_PROXIES` | _(empty)_                  | Proxies whose `X-Forwarded-For` may key rate-limit buckets     |
 
 ## Docker
 
@@ -251,7 +252,7 @@ A password-protected admin backend runs on a separate port (default 8001):
 - **Runtime Config** — edit LLM provider, model, and processing settings without restart
 - **Log Streaming** — real-time SSE-based log viewer
 - **System Status** — cache size, disk space, loaded periods, pipeline history
-- **Authentication** — bcrypt password + IP whitelist + session cookies
+- **Authentication** — bcrypt password + IP whitelist + session cookies + rate-limited login (5 attempts/minute)
 
 ## Documentation
 

--- a/pspcz_analyzer/admin/routes.py
+++ b/pspcz_analyzer/admin/routes.py
@@ -24,6 +24,7 @@ from pspcz_analyzer.models.pipeline_progress import (
     PipelineStage,
     TiskMode,
 )
+from pspcz_analyzer.rate_limit import limiter
 from pspcz_analyzer.services.data_service import DataService
 from pspcz_analyzer.services.pipeline_lock import pipeline_lock
 from pspcz_analyzer.services.runtime_config import (
@@ -120,12 +121,13 @@ async def login_page(request: Request) -> HTMLResponse:
 
 
 @router.post("/login", response_model=None)
+@limiter.limit("5/minute")
 async def login_submit(
     request: Request,
     username: str = Form(...),
     password: str = Form(...),
 ) -> RedirectResponse | HTMLResponse:
-    """Authenticate admin user."""
+    """Authenticate admin user (rate-limited: 5 attempts/minute per client IP)."""
     if username != ADMIN_USERNAME or not verify_password(password):
         return templates.TemplateResponse(
             "login.html",
@@ -146,7 +148,8 @@ async def login_submit(
 
 
 @router.post("/logout")
-async def logout() -> RedirectResponse:
+@limiter.limit("10/minute")
+async def logout(request: Request) -> RedirectResponse:  # request: used by slowapi's limiter
     """Clear admin session."""
     response = RedirectResponse(url="/admin/login", status_code=303)
     response.delete_cookie(_SESSION_COOKIE)
@@ -434,8 +437,9 @@ async def pipeline_history_endpoint(request: Request) -> list[dict]:
 
 
 @router.get("/api/pipeline/logs")
+@limiter.exempt
 async def pipeline_logs_sse() -> StreamingResponse:
-    """SSE endpoint for real-time pipeline log streaming."""
+    """SSE endpoint for real-time pipeline log streaming (exempt: long-lived connection)."""
     return StreamingResponse(
         log_broadcaster.subscribe(),
         media_type="text/event-stream",
@@ -475,6 +479,7 @@ async def get_config(request: Request) -> dict:
 
 
 @router.post("/api/config")
+@limiter.limit("10/minute")
 async def update_config(request: Request) -> dict:
     """Update runtime config from form data."""
     svc = request.app.state.data

--- a/pspcz_analyzer/config.py
+++ b/pspcz_analyzer/config.py
@@ -202,3 +202,10 @@ ADMIN_PORT = int(os.environ.get("ADMIN_PORT", "8001"))
 # Mark the session cookie Secure so it is never sent over plain HTTP.
 # Defaults off in dev mode (plain-HTTP localhost), on everywhere else.
 ADMIN_COOKIE_SECURE = os.environ.get("ADMIN_COOKIE_SECURE", "0" if DEV else "1") == "1"
+
+# Rate limiting — slowapi bucket keys (both processes share the key function)
+# Proxies whose X-Forwarded-For may identify the real client for rate-limit
+# bucketing. Empty by default: buckets key on the TCP peer, so limit keys can
+# never be spoofed. Behind a reverse proxy, set this to the proxy's IP/CIDR —
+# otherwise every visitor shares one bucket and limits trip for all of them.
+RATE_LIMIT_TRUSTED_PROXIES = os.environ.get("RATE_LIMIT_TRUSTED_PROXIES", "")

--- a/pspcz_analyzer/main_backend.py
+++ b/pspcz_analyzer/main_backend.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 import uvicorn
 from fastapi import FastAPI
 from loguru import logger
+from slowapi.errors import RateLimitExceeded
 from starlette.responses import RedirectResponse
 
 from pspcz_analyzer.admin.auth import AdminAuthMiddleware
@@ -13,6 +14,7 @@ from pspcz_analyzer.admin.pipeline_history import PipelineHistory
 from pspcz_analyzer.admin.routes import router as admin_router
 from pspcz_analyzer.config import ADMIN_PASSWORD_HASH, ADMIN_PORT, DEFAULT_PERIOD, DEV
 from pspcz_analyzer.logging_config import setup_logging
+from pspcz_analyzer.rate_limit import html_rate_limit_exceeded_handler, limiter
 from pspcz_analyzer.services.daily_refresh_service import DailyRefreshService
 from pspcz_analyzer.services.data_service import DataService
 from pspcz_analyzer.services.runtime_config import (
@@ -66,6 +68,10 @@ app = FastAPI(
     docs_url=None,
     redoc_url=None,
 )
+
+# Security: rate limiting (login brute-force protection; 60/min default elsewhere)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, html_rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
 # Admin auth: IP whitelist + session
 app.add_middleware(AdminAuthMiddleware)

--- a/pspcz_analyzer/rate_limit.py
+++ b/pspcz_analyzer/rate_limit.py
@@ -1,10 +1,46 @@
 """Rate limiting configuration via slowapi."""
 
+from fastapi import Request
+from fastapi.responses import HTMLResponse
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
+
+from pspcz_analyzer.config import RATE_LIMIT_TRUSTED_PROXIES
+from pspcz_analyzer.proxy import extract_client_ip, parse_ip_networks
+
+_trusted_proxies = parse_ip_networks(RATE_LIMIT_TRUSTED_PROXIES)
+
+
+def get_rate_limit_key(request: Request) -> str:
+    """Bucket key: the TCP peer, or the XFF client behind a trusted proxy.
+
+    With ``RATE_LIMIT_TRUSTED_PROXIES`` empty (the default) X-Forwarded-For
+    is never honored, so limit keys cannot be spoofed. Behind a reverse
+    proxy, list the proxy's address to bucket by the real client instead
+    of sharing one bucket across every visitor.
+    """
+    if not _trusted_proxies:
+        client = request.client
+        return client.host if client else "0.0.0.0"
+    return extract_client_ip(request, _trusted_proxies)
+
 
 limiter = Limiter(
-    key_func=get_remote_address,
+    key_func=get_rate_limit_key,
     default_limits=["60/minute"],
     storage_uri="memory://",
 )
+
+
+async def html_rate_limit_exceeded_handler(
+    _request: Request, exc: RateLimitExceeded
+) -> HTMLResponse:
+    """Render a plain HTML 429 for browser-facing apps (the admin dashboard)."""
+    return HTMLResponse(
+        content=(
+            "<h1>429 &mdash; Too Many Requests</h1>"
+            f"<p>{exc.detail}</p>"
+            "<p>Slow down and try again in a minute.</p>"
+        ),
+        status_code=429,
+    )

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -122,6 +122,25 @@ def test_login_wrong_password_returns_401(client, request: pytest.FixtureRequest
     assert response.status_code == 401
 
 
+def test_login_brute_force_rate_limited(client, admin_password):
+    """The 6th login attempt within a minute is rejected — even with the right password."""
+    for _ in range(5):
+        response = client.post(
+            "/admin/login",
+            data={"username": "admin", "password": "wrong"},
+            headers=ORIGIN,
+        )
+        assert response.status_code == 401
+
+    response = client.post(
+        "/admin/login",
+        data={"username": "admin", "password": admin_password},
+        headers=ORIGIN,
+    )
+    assert response.status_code == 429
+    assert "Too Many Requests" in response.text
+
+
 def test_login_success_sets_secure_cookie(client, admin_password):
     response = client.post(
         "/admin/login",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,17 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
+from pspcz_analyzer.rate_limit import limiter
 from pspcz_analyzer.services.data_service import DataService
 from tests.fixtures.sample_data import make_period_data
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """Keep the global slowapi limiter from leaking bucket state between tests."""
+    limiter.reset()
+    yield
+    limiter.reset()
 
 
 @pytest.fixture()


### PR DESCRIPTION
> **Stacked on #62** — targets the `fix/admin-auth-security` branch because it reuses `pspcz_analyzer.proxy.extract_client_ip`. Retarget to `main` once #62 merges.

## What

Fixes **S2 (HIGH)** from the audit: `main_backend` installed no rate limiter at all, so `POST /admin/login` was brute-forceable. bcrypt slows guesses but doesn't stop a distributed attack, and the IP whitelist is bypassable behind a mis-set proxy.

## How

- **`main_backend.py`** wires slowapi exactly like the frontend: shared `limiter` on `app.state` + a `RateLimitExceeded` handler rendering a plain HTML 429 (the dashboard is browser-facing, no JSON API clients).
- **Per-endpoint limits** in `admin/routes.py`:
  - `POST /admin/login` → **5/minute**
  - `POST /admin/logout`, `POST /admin/api/config` → **10/minute**
  - everything else inherits the **60/minute** default
  - SSE log stream → `@limiter.exempt` (long-lived connection)
- **Proxy-aware key function** in `rate_limit.py`: new `RATE_LIMIT_TRUSTED_PROXIES` (default **empty**). Buckets key on the TCP peer unless the peer is a configured trusted proxy — so limit keys can never be spoofed, and it replaces `get_remote_address` for *both* processes with identical behavior under the default empty config. Behind a reverse proxy, set it to the proxy's address or every visitor shares one bucket.

## Tests

- **Autouse `limiter.reset()` fixture** in `conftest.py` — the limiter is a global singleton; without the reset, bucket state leaks across tests and causes sporadic 429s.
- **Brute-force regression test**: 5 failed logins → 6th attempt *with the correct password* → 429.

## Verification

- `ruff format` + `ruff check --fix` — clean
- `pytest -m "not integration" --cov -q` — **508 passed, 26 deselected, coverage 56.38%** (baseline 507)
- `pyright` — 0 errors, 0 warnings

New env var `RATE_LIMIT_TRUSTED_PROXIES` documented in README, `.env.example`, `CLAUDE.md`.