### PR TITLE
fix(data): atomic writes, safe downloads, encoding, negative-cache TTL (B2–B5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,10 @@ DAILY_REFRESH_HOUR=3
 # Set to "0" to disable entirely.
 AMENDMENTS_ENABLED=1
 
+# Seconds a missing steno page (HTTP 404) stays negatively cached (default
+# 604800 = 7 days). Only 404s are cached; timeouts and 5xx always retry.
+# STENO_NEGATIVE_CACHE_TTL=604800
+
 # --- Version diff cost control ---
 # Max version pairs to compare per tisk (0 = all, 2 = last 2 pairs).
 # Reduces LLM calls by ~60-75% for tisky with many versions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Environment variables are loaded from `.env` via `python-dotenv` (see `.env.exam
 - `ADMIN_TRUSTED_PROXIES` — comma-separated IP/CIDR of reverse proxies whose `X-Forwarded-For` is trusted to identify the client (default: `127.0.0.1,::1`; XFF from any other peer is ignored)
 - `ADMIN_COOKIE_SECURE` — send the admin session cookie only over HTTPS (default: `1` outside dev mode)
 - `RATE_LIMIT_TRUSTED_PROXIES` — comma-separated IP/CIDR of proxies whose `X-Forwarded-For` may key rate-limit buckets (default: empty — buckets key on the TCP peer, spoof-proof; set to the proxy's address behind a reverse proxy)
+- `STENO_NEGATIVE_CACHE_TTL` — seconds a missing steno page (HTTP 404) stays negatively cached (default: `604800` = 7 days; only 404s are cached — timeouts/5xx always retry)
 
 ## Architecture
 
@@ -64,6 +65,8 @@ Environment variables are loaded from `.env` via `python-dotenv` (see `.env.exam
 1. **`data/downloader.py`** — Downloads ZIP files from `psp.cz/eknih/cdrom/opendata` (voting, MPs, sessions, prints) via httpx
 2. **`data/parser.py`** — Parses UNL files (pipe-delimited, Windows-1250 encoded, no headers, trailing pipe) into Polars DataFrames
 3. **`data/cache.py`** — Parquet caching layer; re-parses only when source files are newer than cached parquet
+
+All pipeline writes go through **`fileio.py`** — atomic (same-dir temp + `os.replace`) helpers `write_parquet_atomic` / `write_json_atomic` / `stream_to_atomic` plus `assert_zip_intact`, so the frontend file watcher can never read a torn file and a crashed/interrupted download never leaves a partial archive.
 
 Column definitions for all UNL tables live in `models/schemas.py`. Column names are Czech (matching psp.cz docs) for traceability.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ All configuration is via environment variables. Copy `.env.example` to `.env` fo
 | `ADMIN_COOKIE_SECURE`     | `1` (off in dev mode)         | Send the admin session cookie only over HTTPS                  |
 | `ADMIN_BIND_ADDR`         | `127.0.0.1`                   | Docker only: host address the admin port is bound to           |
 | `RATE_LIMIT_TRUSTED_PROXIES` | _(empty)_                  | Proxies whose `X-Forwarded-For` may key rate-limit buckets     |
+| `STENO_NEGATIVE_CACHE_TTL`   | `604800` (7 days)          | Seconds a steno-page 404 stays negatively cached               |
 
 ## Docker
 

--- a/pspcz_analyzer/admin/pipeline_history.py
+++ b/pspcz_analyzer/admin/pipeline_history.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from loguru import logger
 
 from pspcz_analyzer.config import DEFAULT_CACHE_DIR
+from pspcz_analyzer.fileio import write_json_atomic
 
 _HISTORY_FILENAME = "pipeline_history.json"
 _MAX_ENTRIES_PER_PERIOD = 20
@@ -46,9 +47,8 @@ class PipelineHistory:
             logger.opt(exception=True).warning("[pipeline-history] Failed to load {}", self._path)
 
     def _save(self) -> None:
-        """Persist history to JSON file."""
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(json.dumps(dict(self._runs), indent=2) + "\n", encoding="utf-8")
+        """Persist history to JSON file (atomic — never leaves a torn file)."""
+        write_json_atomic(dict(self._runs), self._path)
 
     def record(self, run: PipelineRun) -> None:
         """Record a completed pipeline run."""

--- a/pspcz_analyzer/config.py
+++ b/pspcz_analyzer/config.py
@@ -124,6 +124,11 @@ STENO_MAX_SUBPAGES_PER_BOD = 250
 # s017212 between s017211 and s017213 is fetched. Small bound keeps it from
 # bridging unrelated segments (e.g. votes split across two sitting days).
 STENO_SUBPAGE_GAP_FILL = 3
+# Negative-cache TTL for steno pages that genuinely don't exist (HTTP 404),
+# in seconds. Only 404s are negative-cached — transient failures (timeouts,
+# 5xx) are retried on the next pipeline run. Markers expire after this TTL so
+# pages psp.cz publishes later are picked up by a future run.
+STENO_NEGATIVE_CACHE_TTL = int(os.environ.get("STENO_NEGATIVE_CACHE_TTL", str(7 * 24 * 3600)))
 
 # LLM provider selection: "ollama" (default) or "openai" (any OpenAI-compatible API)
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", "ollama")

--- a/pspcz_analyzer/data/cache.py
+++ b/pspcz_analyzer/data/cache.py
@@ -7,6 +7,7 @@ import polars as pl
 from loguru import logger
 
 from pspcz_analyzer.config import DEFAULT_CACHE_DIR, PARQUET_DIR
+from pspcz_analyzer.fileio import write_parquet_atomic
 
 
 def _parquet_dir(cache_dir: Path) -> Path:
@@ -38,7 +39,8 @@ def get_or_parse(
 
     logger.info("Parsing {} (cache miss or stale)", table_name)
     df = parse_fn()
-    df.write_parquet(parquet_path)
+    # Atomic: the frontend file watcher may read this path at any moment.
+    write_parquet_atomic(df, parquet_path)
     logger.info("Cached {} ({} rows)", table_name, df.height)
     return df
 

--- a/pspcz_analyzer/data/downloader.py
+++ b/pspcz_analyzer/data/downloader.py
@@ -17,6 +17,7 @@ from pspcz_analyzer.config import (
     TISKY_URL,
     VOTING_URL_TEMPLATE,
 )
+from pspcz_analyzer.fileio import assert_zip_intact, stream_to_atomic
 
 
 def _ensure_dirs(cache_dir: Path) -> tuple[Path, Path]:
@@ -28,7 +29,12 @@ def _ensure_dirs(cache_dir: Path) -> tuple[Path, Path]:
 
 
 def _download_file(url: str, dest: Path, force: bool = False) -> Path:
-    """Download a file if it doesn't exist or force is True."""
+    """Download a file if it doesn't exist or force is True.
+
+    The payload is streamed to a temp file and moved into place atomically,
+    then verified as an intact ZIP, so ``dest`` is either a complete archive
+    or absent — never a truncated partial download.
+    """
     if dest.exists() and not force:
         logger.info("Using cached {}", dest.name)
         return dest
@@ -37,12 +43,29 @@ def _download_file(url: str, dest: Path, force: bool = False) -> Path:
     with httpx.Client(timeout=120, follow_redirects=True) as client:
         with client.stream("GET", url) as response:
             response.raise_for_status()
-            with open(dest, "wb") as f:
-                for chunk in response.iter_bytes(chunk_size=65536):
-                    f.write(chunk)
+            stream_to_atomic(response, dest)
 
+    _verify_zip(dest)
     logger.info("Downloaded {} ({:.1f} MB)", dest.name, dest.stat().st_size / 1e6)
     return dest
+
+
+def _verify_zip(zip_path: Path) -> None:
+    """Verify a freshly downloaded archive, discarding it if corrupt.
+
+    A truncated download would otherwise pass the mtime freshness check and
+    fail extraction on every subsequent run. Removing it here makes the
+    failure loud now and self-heals with a clean re-download next run.
+
+    Raises:
+        zipfile.BadZipFile: If the archive is corrupt (after deleting it).
+    """
+    try:
+        assert_zip_intact(zip_path)
+    except zipfile.BadZipFile:
+        logger.error("Downloaded archive {} is corrupt — removing for re-download", zip_path.name)
+        zip_path.unlink(missing_ok=True)
+        raise
 
 
 def _extract_zip(zip_path: Path, dest_dir: Path) -> Path:

--- a/pspcz_analyzer/data/parser.py
+++ b/pspcz_analyzer/data/parser.py
@@ -24,7 +24,10 @@ def parse_unl(
         logger.info("Skipping empty file {}", file_path.name)
         return pl.DataFrame({c: pl.Series([], dtype=pl.Utf8) for c in columns})
 
-    text = raw_bytes.decode(UNL_ENCODING)
+    # Windows-1250 leaves five byte values undefined (0x81, 0x83, 0x88, 0x90,
+    # 0x98); a stray one must not crash the whole period load. Replace them
+    # with U+FFFD instead of raising.
+    text = raw_bytes.decode(UNL_ENCODING, errors="replace")
     utf8_bytes = text.encode("utf-8")
 
     # UNL has trailing pipe -> extra column

--- a/pspcz_analyzer/fileio.py
+++ b/pspcz_analyzer/fileio.py
@@ -1,0 +1,120 @@
+"""Atomic file I/O helpers shared across the data pipelines.
+
+The frontend and backend processes share one cache directory (a Docker bind
+mount in production) and the frontend's file watcher reloads pipeline outputs
+whenever their mtime changes. Plain writes leave a window where the file is
+truncated or half-written, so a concurrent reader can crash on a torn parquet
+or a crash mid-write can corrupt the file permanently. These helpers always
+write to a temp file in the destination's directory and then move it into
+place with ``os.replace`` (atomic within one filesystem).
+"""
+
+import json
+import os
+import tempfile
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import polars as pl
+
+_CHUNK_SIZE = 65536
+
+
+def _atomic_write(path: Path, writer: Callable[[Path], None]) -> None:
+    """Write ``path`` atomically via a same-directory temp file + ``os.replace``.
+
+    The temp file must live in the destination's directory: ``os.replace`` is
+    atomic only within a single filesystem and fails with EXDEV across devices
+    (e.g. /tmp vs. a Docker bind mount).
+
+    Args:
+        path: Destination file path.
+        writer: Callback that writes the payload to the temp path it receives.
+            If it raises, the temp file is removed and ``path`` is left
+            untouched.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    os.close(fd)
+    tmp = Path(tmp_name)
+    try:
+        # mkstemp creates files with mode 0600; restore normal permissions so
+        # the cache stays world-readable (other container users read it too).
+        os.chmod(tmp, 0o644)
+        writer(tmp)
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _write_parquet(df: pl.DataFrame, tmp: Path) -> None:
+    """Write a DataFrame to a temp path (writer callback for ``_atomic_write``)."""
+    df.write_parquet(tmp)
+
+
+def write_parquet_atomic(df: pl.DataFrame, path: Path) -> None:
+    """Write a DataFrame as parquet without exposing a torn file to readers.
+
+    Args:
+        df: DataFrame to persist.
+        path: Destination parquet path.
+    """
+    _atomic_write(path, lambda tmp: _write_parquet(df, tmp))
+
+
+def _write_json(data: Any, tmp: Path) -> None:
+    """Serialize JSON to a temp path (writer callback for ``_atomic_write``)."""
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_json_atomic(data: Any, path: Path) -> None:
+    """Write a JSON-serializable object atomically (indented, trailing newline).
+
+    Args:
+        data: JSON-serializable payload.
+        path: Destination JSON path.
+    """
+    _atomic_write(path, lambda tmp: _write_json(data, tmp))
+
+
+def _stream_chunks(response: httpx.Response, tmp: Path, chunk_size: int) -> None:
+    """Copy a streamed response body to a file in chunks."""
+    with open(tmp, "wb") as f:
+        for chunk in response.iter_bytes(chunk_size=chunk_size):
+            f.write(chunk)
+
+
+def stream_to_atomic(response: httpx.Response, dest: Path, chunk_size: int = _CHUNK_SIZE) -> None:
+    """Stream an open httpx response body to ``dest`` atomically.
+
+    A failure mid-stream (connection reset, timeout) removes the temp file and
+    leaves ``dest`` absent rather than truncated, so the next run downloads
+    cleanly instead of tripping over a partial file.
+
+    Args:
+        response: Response from ``client.stream(...)``, used inside its context
+            manager.
+        dest: Destination file path.
+        chunk_size: Read chunk size in bytes.
+    """
+    _atomic_write(dest, lambda tmp: _stream_chunks(response, tmp, chunk_size))
+
+
+def assert_zip_intact(path: Path) -> None:
+    """Verify that a ZIP archive is complete and all members pass CRC checks.
+
+    Args:
+        path: Path to the ZIP file.
+
+    Raises:
+        zipfile.BadZipFile: If the archive structure is corrupt or a member
+            fails its CRC check.
+    """
+    with zipfile.ZipFile(path) as zf:
+        bad_member = zf.testzip()
+    if bad_member is not None:
+        raise zipfile.BadZipFile(f"Corrupt member in {path.name}: {bad_member}")

--- a/pspcz_analyzer/services/amendments/cache_manager.py
+++ b/pspcz_analyzer/services/amendments/cache_manager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import polars as pl
 from loguru import logger
 
+from pspcz_analyzer.fileio import write_parquet_atomic
 from pspcz_analyzer.models.amendment_models import AmendmentVote, BillAmendmentData
 
 AMENDMENTS_SCHEMA = {
@@ -208,7 +209,8 @@ def save_amendments(
 
     df = pl.DataFrame(rows, schema=AMENDMENTS_SCHEMA)
     path = _cache_path(cache_dir, period)
-    df.write_parquet(path)
+    # Atomic — the frontend may read this parquet at any moment.
+    write_parquet_atomic(df, path)
     logger.info(
         "Saved {} amendment rows for {} bills (period {}) to {}",
         len(rows),

--- a/pspcz_analyzer/services/amendments/steno_scraper.py
+++ b/pspcz_analyzer/services/amendments/steno_scraper.py
@@ -28,6 +28,7 @@ from pspcz_analyzer.config import (
     PERIOD_YEARS,
     PSP_REQUEST_DELAY,
     STENO_MAX_SUBPAGES_PER_BOD,
+    STENO_NEGATIVE_CACHE_TTL,
     STENO_SUBPAGE_GAP_FILL,
     UNL_ENCODING,
 )
@@ -98,40 +99,104 @@ def _steno_cache_dir(cache_dir: Path, period: int) -> Path:
 _NEGATIVE_CACHE_MARKER = "<<NEGATIVE_CACHE>>"
 
 
+def _parse_negative_expiry(content: str) -> float | None:
+    """Interpret cached file content as a negative-cache marker.
+
+    Args:
+        content: Full content of a steno cache file.
+
+    Returns:
+        None if the content is real HTML (a positive cache hit), otherwise
+        the marker's expiry epoch in seconds. The bare legacy marker written
+        by older versions (no expiry suffix) is reported as ``0.0`` — i.e.
+        already expired — so permanently-poisoned caches retry once.
+    """
+    if content == _NEGATIVE_CACHE_MARKER:
+        return 0.0
+    prefix = f"{_NEGATIVE_CACHE_MARKER}:"
+    if not content.startswith(prefix):
+        return None
+    try:
+        return float(content[len(prefix) :])
+    except ValueError:
+        # Unparseable marker — treat as expired so it is retried and rewritten.
+        return 0.0
+
+
+def _write_negative_cache(cache_file: Path) -> None:
+    """Write a negative-cache marker that expires after STENO_NEGATIVE_CACHE_TTL."""
+    expires = time.time() + STENO_NEGATIVE_CACHE_TTL
+    cache_file.write_text(f"{_NEGATIVE_CACHE_MARKER}:{expires}", encoding="utf-8")
+
+
+def _fetch_steno_page(url: str) -> str | None:
+    """Fetch a URL, caching 404s negatively but leaving transient failures retryable.
+
+    Args:
+        url: URL to download.
+
+    Returns:
+        Decoded HTML, or None if the page is missing or the request failed.
+    """
+    try:
+        resp = httpx.get(url, timeout=30.0, follow_redirects=True)
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            # Genuinely missing — cache the miss so reruns skip the request.
+            logger.warning("[amendment pipeline] Not found (404): {}", url)
+            raise
+        # 5xx etc. are transient; don't poison the cache.
+        logger.warning("[amendment pipeline] HTTP {} for {}", exc.response.status_code, url)
+        return None
+    except httpx.HTTPError:
+        # Timeouts / connection errors are transient; don't poison the cache.
+        logger.warning("[amendment pipeline] Failed to fetch: {}", url)
+        return None
+
+    html = _detect_decode(resp.content)
+    time.sleep(PSP_REQUEST_DELAY)
+    return html
+
+
 def _download_cached(
     url: str,
     cache_file: Path,
 ) -> str | None:
-    """Download a URL with caching and rate limiting.
+    """Download a URL with positive caching and TTL-bounded negative caching.
 
-    Uses negative caching: when a download fails (404, timeout, etc.),
-    a sentinel marker file is written so subsequent calls skip the HTTP
-    request entirely.
+    Only genuine HTTP 404s are negative-cached (with an expiry), so a page
+    psp.cz publishes later is picked up after STENO_NEGATIVE_CACHE_TTL.
+    Transient failures (timeouts, 5xx) return None without writing a marker
+    and are retried on the next pipeline run — previously ANY HTTP error
+    poisoned the cache permanently.
 
     Args:
         url: URL to download.
         cache_file: Local file to cache the result.
 
     Returns:
-        HTML content as string, or None on failure.
+        HTML content as string, or None on failure or negative-cached miss.
     """
     if cache_file.exists():
         content = cache_file.read_text(encoding="utf-8", errors="replace")
-        if content == _NEGATIVE_CACHE_MARKER:
+        expiry = _parse_negative_expiry(content)
+        if expiry is None:
+            return content
+        if time.time() < expiry:
             return None
-        return content
+        # Expired negative marker — fall through and retry the download.
 
     try:
-        resp = httpx.get(url, timeout=30.0, follow_redirects=True)
-        resp.raise_for_status()
-        html = _detect_decode(resp.content)
-        cache_file.write_text(html, encoding="utf-8")
-        time.sleep(PSP_REQUEST_DELAY)
-        return html
-    except httpx.HTTPError:
-        logger.warning("[amendment pipeline] Failed to fetch: {}", url)
-        cache_file.write_text(_NEGATIVE_CACHE_MARKER, encoding="utf-8")
+        html = _fetch_steno_page(url)
+    except httpx.HTTPStatusError:
+        _write_negative_cache(cache_file)
         return None
+
+    if html is None:
+        return None
+    cache_file.write_text(html, encoding="utf-8")
+    return html
 
 
 # ── Index page parsing ────────────────────────────────────────────────────

--- a/pspcz_analyzer/services/runtime_config.py
+++ b/pspcz_analyzer/services/runtime_config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from loguru import logger
 
 from pspcz_analyzer.config import DEFAULT_CACHE_DIR
+from pspcz_analyzer.fileio import write_json_atomic
 
 _RUNTIME_CONFIG_FILENAME = "runtime_config.json"
 
@@ -124,10 +125,9 @@ def load_runtime_config(cache_dir: Path = DEFAULT_CACHE_DIR) -> RuntimeConfig:
 
 
 def save_runtime_config(config: RuntimeConfig, cache_dir: Path = DEFAULT_CACHE_DIR) -> None:
-    """Persist runtime config to JSON file."""
+    """Persist runtime config to JSON file (atomic — never leaves a torn file)."""
     path = _config_path(cache_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(config.to_dict(), indent=2) + "\n", encoding="utf-8")
+    write_json_atomic(config.to_dict(), path)
     logger.info("[runtime-config] Saved to {}", path)
 
 

--- a/pspcz_analyzer/services/tisk/classifier.py
+++ b/pspcz_analyzer/services/tisk/classifier.py
@@ -7,6 +7,7 @@ import polars as pl
 from loguru import logger
 
 from pspcz_analyzer.config import TISKY_META_DIR
+from pspcz_analyzer.fileio import write_parquet_atomic
 from pspcz_analyzer.services.llm import (
     LLMClient,
     create_llm_client,
@@ -111,8 +112,8 @@ def classify_and_save(
         records.append(record)
 
         # Save after every tisk so progress is never lost
-        df = pl.DataFrame(records)
-        df.write_parquet(parquet_path)
+        # (atomic — the frontend may read this parquet at any moment)
+        write_parquet_atomic(pl.DataFrame(records), parquet_path)
 
         if progress_callback is not None:
             progress_callback(i, total)
@@ -296,9 +297,8 @@ def consolidate_topics(
         new_topics_en = _apply_topic_mapping(old_topics_en, mapping_en)
         r["topic_en"] = serialize_topics(new_topics_en)
 
-    # Re-write parquet
-    df = pl.DataFrame(records)
-    df.write_parquet(parquet_path)
+    # Re-write parquet (atomic — the frontend may read it at any moment)
+    write_parquet_atomic(pl.DataFrame(records), parquet_path)
 
     # Write marker so we don't re-consolidate on next startup
     consolidated_marker.touch()

--- a/pspcz_analyzer/services/tisk/io/downloader.py
+++ b/pspcz_analyzer/services/tisk/io/downloader.py
@@ -12,7 +12,20 @@ from pspcz_analyzer.config import (
     PSP_REQUEST_DELAY,
     TISKY_PDF_DIR,
 )
+from pspcz_analyzer.fileio import stream_to_atomic
 from pspcz_analyzer.services.tisk.io.scraper import get_best_pdf
+
+
+def _stream_pdf(url: str, dest: Path) -> None:
+    """Stream a URL to ``dest`` atomically.
+
+    On failure ``dest`` is left untouched (never a partial PDF), so a stale
+    cached copy survives a failed re-download.
+    """
+    with httpx.Client(timeout=60, follow_redirects=True) as client:
+        with client.stream("GET", url) as response:
+            response.raise_for_status()
+            stream_to_atomic(response, dest)
 
 
 def download_tisk_pdf(
@@ -39,15 +52,9 @@ def download_tisk_pdf(
     logger.info("Downloading PDF tisk {}/{} (idd={}) ...", period, ct, doc.idd)
 
     try:
-        with httpx.Client(timeout=60, follow_redirects=True) as client:
-            with client.stream("GET", url) as response:
-                response.raise_for_status()
-                with open(dest, "wb") as f:
-                    for chunk in response.iter_bytes(chunk_size=65536):
-                        f.write(chunk)
+        _stream_pdf(url, dest)
     except httpx.HTTPError:
         logger.exception("Failed to download tisk {}/{}", period, ct)
-        dest.unlink(missing_ok=True)
         return None
 
     logger.info("Downloaded {} ({:.1f} KB)", dest.name, dest.stat().st_size / 1e3)
@@ -75,15 +82,9 @@ def download_subtisk_pdf(
     logger.info("Downloading sub-tisk PDF {}/{}/{} (idd={}) ...", period, ct, ct1, idd)
 
     try:
-        with httpx.Client(timeout=60, follow_redirects=True) as client:
-            with client.stream("GET", url) as response:
-                response.raise_for_status()
-                with open(dest, "wb") as f:
-                    for chunk in response.iter_bytes(chunk_size=65536):
-                        f.write(chunk)
+        _stream_pdf(url, dest)
     except httpx.HTTPError:
         logger.exception("Failed to download sub-tisk {}/{}/{}", period, ct, ct1)
-        dest.unlink(missing_ok=True)
         return None
 
     logger.info("Downloaded {} ({:.1f} KB)", dest.name, dest.stat().st_size / 1e3)

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,5 +1,6 @@
 """Tests for parquet caching layer."""
 
+import os
 import time
 
 import polars as pl
@@ -12,8 +13,9 @@ class TestGetOrParse:
         """Data should be cached as parquet and loaded back identically."""
         source = tmp_path / "source.unl"
         source.write_text("dummy")
-        # Ensure source mtime is settled before creating the cache
-        time.sleep(0.05)
+        # Pin the source mtime far in the past so the parquet written below is
+        # guaranteed newer — deterministic, no sleep-based mtime races.
+        os.utime(source, (0, 0))
 
         df_orig = pl.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
         result = get_or_parse(
@@ -49,9 +51,10 @@ class TestGetOrParse:
         df_v1 = pl.DataFrame({"val": [1]})
         get_or_parse("stale_test", source, lambda: df_v1, cache_dir=test_cache_dir)
 
-        # Make source newer than cache
-        time.sleep(0.1)
+        # Make the source newer than the cache by bumping its mtime forward.
         source.write_text("v2")
+        future = time.time() + 60
+        os.utime(source, (future, future))
 
         df_v2 = pl.DataFrame({"val": [2]})
         result = get_or_parse("stale_test", source, lambda: df_v2, cache_dir=test_cache_dir)

--- a/tests/unit/test_fileio.py
+++ b/tests/unit/test_fileio.py
@@ -1,0 +1,123 @@
+"""Tests for atomic file I/O helpers."""
+
+import json
+import zipfile
+from unittest.mock import MagicMock
+
+import httpx
+import polars as pl
+import pytest
+
+from pspcz_analyzer.fileio import (
+    assert_zip_intact,
+    stream_to_atomic,
+    write_json_atomic,
+    write_parquet_atomic,
+)
+
+
+class TestWriteParquetAtomic:
+    def test_round_trip(self, tmp_path):
+        """Atomic parquet write should be readable and identical."""
+        df = pl.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+        dest = tmp_path / "out.parquet"
+        write_parquet_atomic(df, dest)
+        assert pl.read_parquet(dest).equals(df)
+
+    def test_replaces_existing(self, tmp_path):
+        """A second write should fully replace the previous file."""
+        dest = tmp_path / "out.parquet"
+        write_parquet_atomic(pl.DataFrame({"v": [1]}), dest)
+        write_parquet_atomic(pl.DataFrame({"v": [2]}), dest)
+        assert pl.read_parquet(dest)["v"].to_list() == [2]
+
+    def test_creates_parent_dirs(self, tmp_path):
+        """Missing parent directories should be created."""
+        dest = tmp_path / "nested" / "deeper" / "out.parquet"
+        write_parquet_atomic(pl.DataFrame({"v": [1]}), dest)
+        assert dest.exists()
+
+
+class TestWriteJsonAtomic:
+    def test_format(self, tmp_path):
+        """Output should be indented, unescaped UTF-8, with trailing newline."""
+        dest = tmp_path / "out.json"
+        write_json_atomic({"město": "Praha"}, dest)
+        text = dest.read_text("utf-8")
+        assert text.endswith("\n")
+        assert "město" in text  # not \\u-escaped
+        assert json.loads(text) == {"město": "Praha"}
+
+    def test_failure_leaves_original_and_no_temp(self, tmp_path):
+        """A failed write must not touch the destination or leak temp files."""
+        dest = tmp_path / "out.json"
+        dest.write_text("original", encoding="utf-8")
+
+        with pytest.raises(TypeError):
+            write_json_atomic({"bad": object()}, dest)
+
+        assert dest.read_text() == "original"
+        assert list(tmp_path.glob(".out.json.*.tmp")) == []
+
+
+class TestStreamToAtomic:
+    def test_streams_chunks(self, tmp_path):
+        """Response chunks should be concatenated into the destination."""
+        response = MagicMock(spec=httpx.Response)
+        response.iter_bytes.return_value = [b"abc", b"def"]
+        dest = tmp_path / "file.bin"
+
+        stream_to_atomic(response, dest)
+
+        assert dest.read_bytes() == b"abcdef"
+
+    def test_mid_stream_failure_leaves_no_partial(self, tmp_path):
+        """A failure mid-download must leave the destination absent."""
+
+        def _interrupted_stream(**_kwargs):
+            yield b"partial"
+            raise httpx.ReadError("connection reset")
+
+        response = MagicMock(spec=httpx.Response)
+        response.iter_bytes.side_effect = _interrupted_stream
+        dest = tmp_path / "file.bin"
+
+        with pytest.raises(httpx.ReadError):
+            stream_to_atomic(response, dest)
+
+        assert not dest.exists()
+        assert list(tmp_path.glob(".file.bin.*.tmp")) == []
+
+
+class TestAssertZipIntact:
+    def test_accepts_valid_archive(self, tmp_path):
+        """A complete archive should pass verification."""
+        zpath = tmp_path / "ok.zip"
+        with zipfile.ZipFile(zpath, "w") as zf:
+            zf.writestr("inner.txt", "hello" * 1000)
+        assert_zip_intact(zpath)
+
+    def test_rejects_truncated_archive(self, tmp_path):
+        """A truncated download should be rejected."""
+        zpath = tmp_path / "trunc.zip"
+        with zipfile.ZipFile(zpath, "w") as zf:
+            zf.writestr("inner.txt", "hello" * 1000)
+        data = zpath.read_bytes()
+        zpath.write_bytes(data[: len(data) // 2])
+
+        with pytest.raises(zipfile.BadZipFile):
+            assert_zip_intact(zpath)
+
+    def test_names_crc_corrupt_member(self, tmp_path):
+        """A member with a flipped byte should be reported by name."""
+        zpath = tmp_path / "crc.zip"
+        with zipfile.ZipFile(zpath, "w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("good.txt", "ok")
+            zf.writestr("bad.txt", "X" * 64)
+
+        raw = bytearray(zpath.read_bytes())
+        raw[raw.index(b"X" * 64)] = ord("Y")
+        zpath.write_bytes(bytes(raw))
+
+        with pytest.raises(zipfile.BadZipFile, match="bad.txt"):
+            assert_zip_intact(zpath)

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -100,3 +100,16 @@ class TestParseUnl:
         )
         assert df["a"].to_list() == [42]
         assert df["b"].to_list() == [100]
+
+    def test_undefined_cp1250_bytes_replaced(self, tmp_path):
+        """Bytes undefined in Windows-1250 (0x81 etc.) must not crash parsing.
+
+        Regression: a single stray byte used to raise UnicodeDecodeError and
+        abort the whole period load; it should decode to U+FFFD instead.
+        """
+        path = tmp_path / "bad_byte.unl"
+        path.write_bytes(b"Jan\x81K|42|")
+        df = parse_unl(path, ["name", "num"])
+        assert df.height == 1
+        assert "�" in df["name"].to_list()[0]
+        assert df["num"].to_list() == ["42"]

--- a/tests/unit/test_steno_negative_cache.py
+++ b/tests/unit/test_steno_negative_cache.py
@@ -1,0 +1,132 @@
+"""Tests for steno scraper caching: TTL-bounded negative cache (audit fix B4)."""
+
+import time
+
+import httpx
+import pytest
+
+from pspcz_analyzer.services.amendments import steno_scraper
+
+_MARKER = steno_scraper._NEGATIVE_CACHE_MARKER
+
+
+def _status_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an HTTPStatusError carrying the given response status."""
+    request = httpx.Request("GET", "https://www.psp.cz/x")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+class _FakeResponse:
+    """Stand-in for httpx.Response with a successful status."""
+
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        """Successful responses never raise."""
+
+
+@pytest.fixture(autouse=True)
+def _no_request_delay(monkeypatch):
+    """Skip the polite-request sleep in every test."""
+    monkeypatch.setattr(steno_scraper, "PSP_REQUEST_DELAY", 0)
+
+
+class TestParseNegativeExpiry:
+    def test_real_html_is_not_a_marker(self):
+        """Ordinary page content is a positive cache hit."""
+        assert steno_scraper._parse_negative_expiry("<html>speech</html>") is None
+
+    def test_bare_legacy_marker_is_expired(self):
+        """The old permanent marker must retry once, not poison forever."""
+        assert steno_scraper._parse_negative_expiry(_MARKER) == 0.0
+
+    def test_marker_with_expiry(self):
+        """A TTL marker reports its expiry epoch."""
+        assert steno_scraper._parse_negative_expiry(f"{_MARKER}:12345.5") == 12345.5
+
+    def test_unparseable_expiry_is_expired(self):
+        """A corrupted marker is treated as expired (retried and rewritten)."""
+        assert steno_scraper._parse_negative_expiry(f"{_MARKER}:garbage") == 0.0
+
+
+class TestDownloadCached:
+    def test_positive_cache_hit_skips_http(self, tmp_path, monkeypatch):
+        """Cached HTML is returned without any network call."""
+        cache_file = tmp_path / "page.html"
+        cache_file.write_text("<html>cached</html>", encoding="utf-8")
+
+        def _fail(*_args, **_kwargs):
+            raise AssertionError("HTTP must not be called on cache hit")
+
+        monkeypatch.setattr(steno_scraper.httpx, "get", _fail)
+        assert steno_scraper._download_cached("https://x", cache_file) == "<html>cached</html>"
+
+    def test_fresh_negative_marker_skips_http(self, tmp_path, monkeypatch):
+        """An unexpired negative marker returns None without a network call."""
+        cache_file = tmp_path / "page.html"
+        cache_file.write_text(f"{_MARKER}:{time.time() + 3600}", encoding="utf-8")
+
+        def _fail(*_args, **_kwargs):
+            raise AssertionError("HTTP must not be called for fresh negative marker")
+
+        monkeypatch.setattr(steno_scraper.httpx, "get", _fail)
+        assert steno_scraper._download_cached("https://x", cache_file) is None
+
+    def test_expired_marker_retries_and_caches(self, tmp_path, monkeypatch):
+        """An expired marker triggers a real download, and success overwrites it."""
+        cache_file = tmp_path / "page.html"
+        cache_file.write_text(f"{_MARKER}:1.0", encoding="utf-8")
+        monkeypatch.setattr(steno_scraper.httpx, "get", lambda *a, **k: _FakeResponse(b"now here"))
+
+        assert steno_scraper._download_cached("https://x", cache_file) == "now here"
+        assert cache_file.read_text(encoding="utf-8") == "now here"
+
+    def test_legacy_marker_retries(self, tmp_path, monkeypatch):
+        """The permanent legacy marker is treated as expired and retried."""
+        cache_file = tmp_path / "page.html"
+        cache_file.write_text(_MARKER, encoding="utf-8")
+        monkeypatch.setattr(steno_scraper.httpx, "get", lambda *a, **k: _FakeResponse(b"found"))
+
+        assert steno_scraper._download_cached("https://x", cache_file) == "found"
+
+    def test_404_writes_ttl_marker(self, tmp_path, monkeypatch):
+        """A genuine 404 is negative-cached with a future expiry."""
+        monkeypatch.setattr(steno_scraper, "STENO_NEGATIVE_CACHE_TTL", 3600)
+
+        def _not_found(*_args, **_kwargs):
+            raise _status_error(404)
+
+        monkeypatch.setattr(steno_scraper.httpx, "get", _not_found)
+        cache_file = tmp_path / "page.html"
+
+        assert steno_scraper._download_cached("https://x", cache_file) is None
+
+        expiry = steno_scraper._parse_negative_expiry(cache_file.read_text(encoding="utf-8"))
+        assert expiry is not None
+        assert expiry > time.time()
+
+    def test_timeout_does_not_poison_cache(self, tmp_path, monkeypatch):
+        """A timeout returns None but writes no marker, so reruns retry."""
+
+        def _timeout(*_args, **_kwargs):
+            raise httpx.ConnectTimeout("timed out")
+
+        monkeypatch.setattr(steno_scraper.httpx, "get", _timeout)
+        cache_file = tmp_path / "page.html"
+
+        assert steno_scraper._download_cached("https://x", cache_file) is None
+        assert not cache_file.exists()
+
+    def test_server_error_does_not_poison_cache(self, tmp_path, monkeypatch):
+        """A 500 returns None but writes no marker, so reruns retry."""
+
+        def _server_error(*_args, **_kwargs):
+            raise _status_error(500)
+
+        monkeypatch.setattr(steno_scraper.httpx, "get", _server_error)
+        cache_file = tmp_path / "page.html"
+
+        assert steno_scraper._download_cached("https://x", cache_file) is None
+        assert not cache_file.exists()


### PR DESCRIPTION
Audit remediation (part 4 of the professionalization series): data-integrity fixes B2–B5.

## Problem

The frontend and backend processes share one cache directory (Docker bind mount in production) and the frontend's file watcher reloads pipeline outputs whenever their mtime changes. Plain writes leave a window where files are truncated or half-written — a concurrent reader can crash on a torn parquet, and a crash/interrupt mid-write corrupts files permanently.

## Changes

- **New `pspcz_analyzer/fileio.py`** — cross-cutting atomic I/O: same-dir temp file + `os.replace` (`write_parquet_atomic`, `write_json_atomic`, `stream_to_atomic`) plus `assert_zip_intact`. Same-dir temp is mandatory: cross-device replace fails EXDEV on bind mounts.
- **B2 — safe downloads** (`data/downloader.py`): downloads stream atomically and ZIP integrity is verified after transfer. A truncated archive previously passed the mtime freshness check and failed extraction on every subsequent run; now it is deleted loudly and re-downloaded cleanly next run. `tisk/io/downloader.py` gains a shared `_stream_pdf` helper and its partial-PDF `unlink` calls become dead (removed) — a failed re-download no longer destroys a good cached copy.
- **B3 — atomic parquet/JSON**: all `df.write_parquet` sites (`data/cache.py`, tisk `classifier.py` ×2, amendments `cache_manager.py`) and the `runtime_config.json` / `pipeline_history.json` writers now go through the atomic helpers. Readers can never observe a torn file.
- **B4 — negative-cache TTL** (`steno_scraper.py`): marker becomes `<<NEGATIVE_CACHE>>:<expiry>` with new `STENO_NEGATIVE_CACHE_TTL` (default 7 days, env-overridable). Only genuine HTTP 404s are negative-cached — previously ANY `httpx.HTTPError` (timeout, 5xx) poisoned the cache permanently. Legacy bare markers are treated as expired, so permanently-poisoned caches retry once and self-heal.
- **B5 — encoding** (`data/parser.py`): cp1250 decode with `errors="replace"`; the five undefined byte values (0x81/0x83/0x88/0x90/0x98) no longer raise and abort a whole period load.

Docs: `STENO_NEGATIVE_CACHE_TTL` in README env table, `.env.example`, CLAUDE.md (+ `fileio.py` architecture note).

## Tests

- New `tests/unit/test_fileio.py` — round trips, failure cleanup (destination untouched, no temp leak), mid-stream interruption, ZIP truncation + CRC-member rejection.
- New `tests/unit/test_steno_negative_cache.py` — marker parsing (incl. legacy/corrupt), 404 vs timeout vs 500 behavior, expiry retry.
- `tests/unit/test_parser.py` — undefined-byte regression.
- `tests/unit/test_cache.py` — sleep-based mtime dance replaced with deterministic `os.utime`.

Gate: **530 passed** (+22), 26 deselected, coverage **57.26%**, `ruff format`/`check` clean, `pyright` 0 errors / 0 warnings / 0 informations.