### PR TITLE
fix(avail): event-loop stalls, timeout pool, unbounded cache (B6, B8–B10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,15 @@ AMENDMENTS_ENABLED=1
 # 604800 = 7 days). Only 404s are cached; timeouts and 5xx always retry.
 # STENO_NEGATIVE_CACHE_TTL=604800
 
+# --- Availability tuning ---
+# Thread pool size for analysis/chart computations (run_with_timeout).
+# 0 (default) = Python's min(32, cpu_count + 4). Raise on busy deployments;
+# the old hard-coded 2 let two slow computations stall all analysis requests.
+# COMPUTE_POOL_WORKERS=0
+
+# Max entries in the in-memory analysis cache before LRU eviction.
+# ANALYSIS_CACHE_MAX_ENTRIES=512
+
 # --- Version diff cost control ---
 # Max version pairs to compare per tisk (0 = all, 2 = last 2 pairs).
 # Reduces LLM calls by ~60-75% for tisky with many versions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Environment variables are loaded from `.env` via `python-dotenv` (see `.env.exam
 - `ADMIN_COOKIE_SECURE` — send the admin session cookie only over HTTPS (default: `1` outside dev mode)
 - `RATE_LIMIT_TRUSTED_PROXIES` — comma-separated IP/CIDR of proxies whose `X-Forwarded-For` may key rate-limit buckets (default: empty — buckets key on the TCP peer, spoof-proof; set to the proxy's address behind a reverse proxy)
 - `STENO_NEGATIVE_CACHE_TTL` — seconds a missing steno page (HTTP 404) stays negatively cached (default: `604800` = 7 days; only 404s are cached — timeouts/5xx always retry)
+- `COMPUTE_POOL_WORKERS` — thread-pool size behind `run_with_timeout` (default: `0` = Python's `min(32, cpu_count + 4)`; previously hard-coded to 2)
+- `ANALYSIS_CACHE_MAX_ENTRIES` — max analysis cache entries before LRU eviction (default: `512`)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ All configuration is via environment variables. Copy `.env.example` to `.env` fo
 | `ADMIN_BIND_ADDR`         | `127.0.0.1`                   | Docker only: host address the admin port is bound to           |
 | `RATE_LIMIT_TRUSTED_PROXIES` | _(empty)_                  | Proxies whose `X-Forwarded-For` may key rate-limit buckets     |
 | `STENO_NEGATIVE_CACHE_TTL`   | `604800` (7 days)          | Seconds a steno-page 404 stays negatively cached               |
+| `COMPUTE_POOL_WORKERS`       | `0` (Python default)       | Analysis thread-pool size (`0` = `min(32, cpu_count + 4)`)     |
+| `ANALYSIS_CACHE_MAX_ENTRIES` | `512`                      | Max entries in the analysis cache (LRU eviction)               |
 
 ## Docker
 

--- a/pspcz_analyzer/config.py
+++ b/pspcz_analyzer/config.py
@@ -208,6 +208,18 @@ ADMIN_PORT = int(os.environ.get("ADMIN_PORT", "8001"))
 # Defaults off in dev mode (plain-HTTP localhost), on everywhere else.
 ADMIN_COOKIE_SECURE = os.environ.get("ADMIN_COOKIE_SECURE", "0" if DEV else "1") == "1"
 
+# Computation thread pool — size of the executor behind run_with_timeout
+# (analysis + chart endpoints). 0 = Python's default min(32, cpu_count + 4).
+# The old hard-coded 2 meant two slow computations exhausted capacity and
+# every other analysis request queued behind them (timed-out work keeps
+# occupying its worker until it finishes — futures cannot be killed).
+COMPUTE_POOL_WORKERS = int(os.environ.get("COMPUTE_POOL_WORKERS", "0"))
+
+# Upper bound on entries in the in-memory analysis cache (LRU eviction).
+# Keys include user-controlled strings (e.g. free-text vote search), so
+# without a cap the cache could grow without limit.
+ANALYSIS_CACHE_MAX_ENTRIES = int(os.environ.get("ANALYSIS_CACHE_MAX_ENTRIES", "512"))
+
 # Rate limiting — slowapi bucket keys (both processes share the key function)
 # Proxies whose X-Forwarded-For may identify the real client for rate-limit
 # bucketing. Empty by default: buckets key on the TCP peer, so limit keys can

--- a/pspcz_analyzer/middleware.py
+++ b/pspcz_analyzer/middleware.py
@@ -14,7 +14,12 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
-_compute_pool = ThreadPoolExecutor(max_workers=2)
+from pspcz_analyzer.config import COMPUTE_POOL_WORKERS
+
+# max_workers=None (COMPUTE_POOL_WORKERS=0) lets Python size the pool as
+# min(32, cpu_count + 4). The previous hard-coded 2 made two slow/timed-out
+# computations starve every other analysis request.
+_compute_pool = ThreadPoolExecutor(max_workers=COMPUTE_POOL_WORKERS or None)
 
 
 def is_same_origin(request: Request) -> bool:
@@ -83,6 +88,11 @@ async def run_with_timeout(
 
     Propagates ContextVars (incl. locale) into the worker thread.
     Returns the result or raises HTTP 503 on timeout.
+
+    Note: a timed-out computation keeps running in its worker thread and its
+    result is discarded — futures cannot be cancelled mid-flight. The pool is
+    sized with headroom (COMPUTE_POOL_WORKERS) so such zombies don't starve
+    subsequent requests.
     """
     loop = asyncio.get_running_loop()
     ctx = contextvars.copy_context()

--- a/pspcz_analyzer/routes/charts.py
+++ b/pspcz_analyzer/routes/charts.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import StreamingResponse
+from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from pspcz_analyzer.config import DEFAULT_PERIOD
@@ -26,14 +27,103 @@ router = APIRouter(tags=["Charts"])
 # Light institutional style
 sns.set_theme(style="whitegrid", palette="deep")
 
+# Rendering itself is fast; the data computations above it have their own,
+# longer timeouts.
+_RENDER_TIMEOUT_S = 10.0
+
 
 def _fig_to_png(fig: Figure) -> io.BytesIO:
-    """Render a matplotlib figure to a PNG BytesIO buffer."""
+    """Render a matplotlib figure to a PNG BytesIO buffer (does not close it)."""
     buf = io.BytesIO()
     fig.savefig(buf, format="png", dpi=200, bbox_inches="tight", facecolor="#FFFFFF")
     buf.seek(0)
-    plt.close(fig)
     return buf
+
+
+def _style_figure(fig: Figure, ax: Axes) -> None:
+    """Apply the shared institutional look: backgrounds, ticks, spine colors."""
+    fig.patch.set_facecolor("#FFFFFF")
+    ax.set_facecolor("#F7F7F7")
+    ax.tick_params(colors="#333333")
+    for spine in ax.spines.values():
+        spine.set_color("#D9D9D9")
+
+
+def _render_loyalty_png(rows: list[dict], xlabel: str, title: str) -> io.BytesIO:
+    """Render the loyalty bar chart to PNG, closing the figure no matter what."""
+    fig, ax = plt.subplots(figsize=(12, max(6, len(rows) * 0.35)))
+    try:
+        _style_figure(fig, ax)
+        names = [f"{r['jmeno']} {r['prijmeni']} ({r['party'] or '?'})" for r in rows]
+        values = [r["rebellion_pct"] for r in rows]
+        colors = sns.color_palette("coolwarm", len(rows))
+        ax.barh(names[::-1], values[::-1], color=colors)
+        ax.set_xlabel(xlabel, color="#333333")
+        ax.set_title(title, color="#333333", fontsize=14)
+        return _fig_to_png(fig)
+    finally:
+        plt.close(fig)
+
+
+def _render_attendance_png(
+    rows: list[dict], field: str, palette: str, xlabel: str, title: str
+) -> io.BytesIO:
+    """Render the attendance bar chart to PNG, closing the figure no matter what."""
+    # Fully-excused MPs have a null attendance rate (attendance_service) and
+    # barh cannot plot None — nulls_last already ranks them last anyway.
+    plottable = [r for r in rows if r[field] is not None]
+    fig, ax = plt.subplots(figsize=(12, max(6, len(plottable) * 0.35)))
+    try:
+        _style_figure(fig, ax)
+        names = [f"{r['jmeno']} {r['prijmeni']} ({r['party'] or '?'})" for r in plottable]
+        values = [r[field] for r in plottable]
+        colors = sns.color_palette(palette, len(plottable))
+        ax.barh(names[::-1], values[::-1], color=colors)
+        ax.set_xlabel(xlabel, color="#333333")
+        ax.set_title(title, color="#333333", fontsize=14)
+        return _fig_to_png(fig)
+    finally:
+        plt.close(fig)
+
+
+def _render_similarity_png(coords: list[dict], xlabel: str, ylabel: str, title: str) -> io.BytesIO:
+    """Render the similarity PCA scatter chart to PNG, closing the figure."""
+    parties = sorted({c["party"] for c in coords})
+    palette = dict(zip(parties, sns.color_palette("husl", len(parties)), strict=False))
+
+    fig, ax = plt.subplots(figsize=(14, 10))
+    try:
+        _style_figure(fig, ax)
+        for party in parties:
+            pts = [c for c in coords if c["party"] == party]
+            ax.scatter(
+                [p["x"] for p in pts],
+                [p["y"] for p in pts],
+                label=party,
+                color=palette[party],
+                s=60,
+                alpha=0.8,
+                edgecolors="#333333",
+                linewidths=0.5,
+            )
+
+        ax.set_xlabel(xlabel, color="#333333")
+        ax.set_ylabel(ylabel, color="#333333")
+        ax.set_title(title, color="#333333", fontsize=14)
+
+        legend = ax.legend(
+            loc="upper right",
+            fontsize=9,
+            framealpha=0.9,
+            facecolor="#FFFFFF",
+            edgecolor="#D9D9D9",
+        )
+        for text in legend.get_texts():
+            text.set_color("#333333")
+
+        return _fig_to_png(fig)
+    finally:
+        plt.close(fig)
 
 
 @router.get("/loyalty.png")
@@ -57,22 +147,12 @@ async def loyalty_chart(
     xlabel = _("chart.loyalty.xlabel")
     title = _("chart.loyalty.title")
 
-    fig, ax = plt.subplots(figsize=(12, max(6, len(rows) * 0.35)))
-    fig.patch.set_facecolor("#FFFFFF")
-    ax.set_facecolor("#F7F7F7")
-
-    names = [f"{r['jmeno']} {r['prijmeni']} ({r['party'] or '?'})" for r in rows]
-    values = [r["rebellion_pct"] for r in rows]
-
-    colors = sns.color_palette("coolwarm", len(rows))
-    ax.barh(names[::-1], values[::-1], color=colors)
-    ax.set_xlabel(xlabel, color="#333333")
-    ax.set_title(title, color="#333333", fontsize=14)
-    ax.tick_params(colors="#333333")
-    for spine in ax.spines.values():
-        spine.set_color("#D9D9D9")
-
-    return StreamingResponse(_fig_to_png(fig), media_type="image/png")
+    buf = await run_with_timeout(
+        lambda: _render_loyalty_png(rows, xlabel, title),
+        timeout=_RENDER_TIMEOUT_S,
+        label="loyalty chart render",
+    )
+    return StreamingResponse(buf, media_type="image/png")
 
 
 @router.get("/attendance.png")
@@ -97,12 +177,6 @@ async def attendance_chart(
         label="attendance chart",
     )
 
-    fig, ax = plt.subplots(figsize=(12, max(6, len(rows) * 0.35)))
-    fig.patch.set_facecolor("#FFFFFF")
-    ax.set_facecolor("#F7F7F7")
-
-    names = [f"{r['jmeno']} {r['prijmeni']} ({r['party'] or '?'})" for r in rows]
-
     chart_meta: dict[str, tuple[str, str, str]] = {
         # sort_key: (data_field, chart_key_prefix, palette)
         "worst": ("attendance_pct", "chart.attendance.worst", "RdYlGn"),
@@ -122,17 +196,12 @@ async def attendance_chart(
     xlabel = _(f"{chart_key}.xlabel")
     title = _(f"{chart_key}.title")
 
-    values = [r[field] for r in rows]
-    colors = sns.color_palette(palette, len(rows))
-    ax.barh(names[::-1], values[::-1], color=colors)
-    ax.set_xlabel(xlabel, color="#333333")
-    ax.set_title(title, color="#333333", fontsize=14)
-
-    ax.tick_params(colors="#333333")
-    for spine in ax.spines.values():
-        spine.set_color("#D9D9D9")
-
-    return StreamingResponse(_fig_to_png(fig), media_type="image/png")
+    buf = await run_with_timeout(
+        lambda: _render_attendance_png(rows, field, palette, xlabel, title),
+        timeout=_RENDER_TIMEOUT_S,
+        label="attendance chart render",
+    )
+    return StreamingResponse(buf, media_type="image/png")
 
 
 @router.get("/similarity.png")
@@ -148,46 +217,14 @@ async def similarity_chart(request: Request, period: int = DEFAULT_PERIOD):
         label="similarity chart",
     )
 
-    # Assign colors per party
-    parties = sorted({c["party"] for c in coords})
-    palette = dict(zip(parties, sns.color_palette("husl", len(parties)), strict=False))
+    # Resolve labels in request context (ContextVar propagated by run_with_timeout)
+    xlabel = _("chart.similarity.xlabel")
+    ylabel = _("chart.similarity.ylabel")
+    title = _("chart.similarity.title")
 
-    fig, ax = plt.subplots(figsize=(14, 10))
-    fig.patch.set_facecolor("#FFFFFF")
-    ax.set_facecolor("#F7F7F7")
-
-    for party in parties:
-        pts = [c for c in coords if c["party"] == party]
-        ax.scatter(
-            [p["x"] for p in pts],
-            [p["y"] for p in pts],
-            label=party,
-            color=palette[party],
-            s=60,
-            alpha=0.8,
-            edgecolors="#333333",
-            linewidths=0.5,
-        )
-
-    ax.set_xlabel(_("chart.similarity.xlabel"), color="#333333")
-    ax.set_ylabel(_("chart.similarity.ylabel"), color="#333333")
-    ax.set_title(
-        _("chart.similarity.title"),
-        color="#333333",
-        fontsize=14,
+    buf = await run_with_timeout(
+        lambda: _render_similarity_png(coords, xlabel, ylabel, title),
+        timeout=_RENDER_TIMEOUT_S,
+        label="similarity chart render",
     )
-    ax.tick_params(colors="#333333")
-    for spine in ax.spines.values():
-        spine.set_color("#D9D9D9")
-
-    legend = ax.legend(
-        loc="upper right",
-        fontsize=9,
-        framealpha=0.9,
-        facecolor="#FFFFFF",
-        edgecolor="#D9D9D9",
-    )
-    for text in legend.get_texts():
-        text.set_color("#333333")
-
-    return StreamingResponse(_fig_to_png(fig), media_type="image/png")
+    return StreamingResponse(buf, media_type="image/png")

--- a/pspcz_analyzer/routes/voting.py
+++ b/pspcz_analyzer/routes/voting.py
@@ -110,11 +110,15 @@ async def votes_api(
     pd = data_svc.get_period(period)
     lang = getattr(request.state, "lang", "cs")
     key = f"votes:{period}:{search}:{outcome}:{topic}:{page}:{lang}"
-    result = analysis_cache.get_or_compute(
-        key,
-        lambda: list_votes(
-            pd, search=search, page=page, outcome_filter=outcome, topic_filter=topic, lang=lang
+    result = await run_with_timeout(
+        lambda: analysis_cache.get_or_compute(
+            key,
+            lambda: list_votes(
+                pd, search=search, page=page, outcome_filter=outcome, topic_filter=topic, lang=lang
+            ),
         ),
+        timeout=15.0,
+        label="votes search",
     )
     return templates.TemplateResponse(
         "partials/votes_list.html",

--- a/pspcz_analyzer/services/analysis_cache.py
+++ b/pspcz_analyzer/services/analysis_cache.py
@@ -1,27 +1,44 @@
-"""In-memory TTL cache for expensive analysis computations."""
+"""In-memory TTL + LRU cache for expensive analysis computations."""
 
 import threading
 import time
+from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any
 
 from loguru import logger
 
+from pspcz_analyzer.config import ANALYSIS_CACHE_MAX_ENTRIES
+
 
 class AnalysisCache:
-    """Thread-safe dict cache with TTL expiry."""
+    """Thread-safe dict cache with TTL expiry and LRU eviction.
 
-    def __init__(self, ttl: int = 3600):
+    Entries expire ``ttl`` seconds after insertion. Independently, once the
+    cache holds more than ``max_entries`` items the least recently used one
+    is evicted — keys include user-controlled strings (free-text search on
+    the votes endpoint), so without a cap the cache could grow without limit.
+    """
+
+    def __init__(self, ttl: int = 3600, max_entries: int = ANALYSIS_CACHE_MAX_ENTRIES) -> None:
         self._ttl = ttl
-        self._store: dict[str, tuple[float, Any]] = {}
+        self._max_entries = max(1, max_entries)
+        self._store: OrderedDict[str, tuple[float, Any]] = OrderedDict()
         self._lock = threading.Lock()
 
     def get_or_compute(self, key: str, compute_fn: Callable[[], Any]) -> Any:
+        """Return the cached value for ``key``, computing and storing it on a miss.
+
+        ``compute_fn`` runs outside the lock, so concurrent misses may compute
+        the same value in parallel — last write wins, which is fine for pure
+        analyses.
+        """
         now = time.monotonic()
         with self._lock:
             if key in self._store:
                 ts, value = self._store[key]
                 if now - ts < self._ttl:
+                    self._store.move_to_end(key)
                     logger.debug("Cache HIT: {}", key)
                     return value
                 del self._store[key]
@@ -31,9 +48,22 @@ class AnalysisCache:
 
         with self._lock:
             self._store[key] = (time.monotonic(), value)
+            self._store.move_to_end(key)
+            self._evict_lru()
         return value
 
+    def _evict_lru(self) -> None:
+        """Drop least-recently-used entries beyond max_entries (lock held)."""
+        while len(self._store) > self._max_entries:
+            evicted, _ = self._store.popitem(last=False)
+            logger.debug("Cache EVICT (LRU): {}", evicted)
+
     def invalidate(self, prefix: str = "") -> int:
+        """Remove cached entries; all of them, or those starting with ``prefix``.
+
+        Returns:
+            Number of entries removed.
+        """
         with self._lock:
             if not prefix:
                 n = len(self._store)

--- a/pspcz_analyzer/services/attendance_service.py
+++ b/pspcz_analyzer/services/attendance_service.py
@@ -39,10 +39,15 @@ def compute_attendance(
         pl.len().alias("total"),
     )
 
+    # Fully-excused MPs have a zero denominator — active / 0 = inf used to
+    # rank them as having PERFECT attendance. Leave the rate undefined (null)
+    # instead; sorting uses nulls_last so they never top either ranking.
+    denom = (pl.col("total") - pl.col("excused")).cast(pl.Float64)
     per_mp = per_mp.with_columns(
-        (pl.col("active") / (pl.col("total") - pl.col("excused")).cast(pl.Float64) * 100).alias(
-            "attendance_pct"
-        )
+        pl.when(denom > 0)
+        .then(pl.col("active") / denom * 100)
+        .otherwise(None)
+        .alias("attendance_pct")
     )
 
     # Join with MP info
@@ -65,7 +70,7 @@ def compute_attendance(
         "most_no": ("no_votes", True),
     }
     col, desc = sort_config.get(sort, ("attendance_pct", False))
-    result = result.sort(col, descending=desc).head(top)
+    result = result.sort(col, descending=desc, nulls_last=True).head(top)
 
     return result.select(
         "jmeno",

--- a/pspcz_analyzer/services/data_reader.py
+++ b/pspcz_analyzer/services/data_reader.py
@@ -435,12 +435,17 @@ class DataReader:
         return max(stamps) if stamps else None
 
     async def _watch_loop(self) -> None:
-        """Poll parquet file mtimes and reload periods with changed data."""
+        """Poll parquet file mtimes and reload periods with changed data.
+
+        The filesystem scan and any period reloads run in worker threads so
+        a large reload (re-parsing several periods) never blocks the event
+        loop — HTTP requests keep being served during a refresh.
+        """
         while True:
             await asyncio.sleep(_WATCH_INTERVAL_S)
             try:
-                self._check_for_updates()
-                self._check_amendment_updates()
+                await asyncio.to_thread(self._check_for_updates)
+                await asyncio.to_thread(self._check_amendment_updates)
             except Exception:
                 logger.opt(exception=True).warning("[file-watcher] Error during check")
 

--- a/pspcz_analyzer/templates/partials/attendance_table.html
+++ b/pspcz_analyzer/templates/partials/attendance_table.html
@@ -28,7 +28,8 @@
                 <td>{{ "{:,}".format(row.passive) }}</td>
                 <td>{{ "{:,}".format(row.absent) }}</td>
                 <td>{{ "{:,}".format(row.excused) }}</td>
-                <td>{{ "%.1f"|format(row.attendance_pct) }}%</td>
+                {# Fully-excused MPs have no defined attendance rate (null) #}
+                <td>{% if row.attendance_pct is not none %}{{ "%.1f"|format(row.attendance_pct) }}%{% else %}—{% endif %}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -1,5 +1,10 @@
 """Tests for HTMX partial endpoints and health check."""
 
+import time
+
+from pspcz_analyzer.middleware import run_with_timeout as real_run_with_timeout
+from pspcz_analyzer.routes import voting
+
 
 class TestHealthEndpoint:
     def test_health_returns_ok(self, client):
@@ -34,3 +39,28 @@ class TestHTMXPartials:
     def test_invalid_period_returns_404(self, client):
         resp = client.get("/api/loyalty?period=999")
         assert resp.status_code == 404
+
+
+class TestVotesTimeout:
+    def test_slow_votes_search_returns_503(self, client, monkeypatch):
+        """A votes search exceeding the compute timeout degrades to HTTP 503.
+
+        Regression (audit fix B8): votes_api was the only analysis endpoint
+        not wrapped in run_with_timeout, so a slow search blocked the event
+        loop instead of returning 503.
+        """
+
+        async def _short_timeout(fn, *args, **kwargs):
+            # Ignore the endpoint's real timeout; force a tiny one.
+            return await real_run_with_timeout(fn, *args, timeout=0.05, label=kwargs["label"])
+
+        monkeypatch.setattr(voting, "run_with_timeout", _short_timeout)
+
+        def _slow_list_votes(*_args, **_kwargs):
+            time.sleep(0.3)
+            return {}
+
+        monkeypatch.setattr(voting, "list_votes", _slow_list_votes)
+
+        resp = client.get("/api/votes?period=1&search=slowpoke")
+        assert resp.status_code == 503

--- a/tests/unit/services/test_attendance.py
+++ b/tests/unit/services/test_attendance.py
@@ -1,7 +1,43 @@
 """Tests for attendance computation."""
 
+import polars as pl
+
+from pspcz_analyzer.models.enums import VoteResult
+from pspcz_analyzer.models.tisk_models import PeriodData
 from pspcz_analyzer.services.attendance_service import compute_attendance
 from tests.fixtures.sample_data import make_period_data
+
+
+def _with_fully_excused_mp() -> PeriodData:
+    """PeriodData extended with MP 99, excused from every single vote."""
+    data = make_period_data()
+    excused_rows = pl.DataFrame(
+        {
+            "id_poslanec": [99] * 5,
+            "id_hlasovani": list(range(1, 6)),
+            "vysledek": [VoteResult.EXCUSED] * 5,
+        },
+        schema={"id_poslanec": pl.Int64, "id_hlasovani": pl.Int64, "vysledek": pl.Utf8},
+    )
+    data.mp_votes = pl.concat([data.mp_votes, excused_rows])
+    extra_info = pl.DataFrame(
+        {
+            "id_poslanec": [99],
+            "id_osoba": [199],
+            "jmeno": ["Věčně"],
+            "prijmeni": ["Omluvený"],
+            "party": ["TOP09"],
+        },
+        schema={
+            "id_poslanec": pl.Int64,
+            "id_osoba": pl.Int64,
+            "jmeno": pl.Utf8,
+            "prijmeni": pl.Utf8,
+            "party": pl.Utf8,
+        },
+    )
+    data.mp_info = pl.concat([data.mp_info, extra_info])
+    return data
 
 
 class TestComputeAttendance:
@@ -43,6 +79,31 @@ class TestComputeAttendance:
         data = make_period_data()
         result = compute_attendance(data, top=2)
         assert len(result) <= 2
+
+    def test_fully_excused_mp_has_null_rate(self):
+        """All-excused MPs get a null rate, not inf (audit fix B6).
+
+        Regression: active / (total - excused) = 0/0 = inf used to rank a
+        permanently-excused MP as having the BEST attendance.
+        """
+        data = _with_fully_excused_mp()
+        result = compute_attendance(data, top=50, sort="worst")
+        excused = [r for r in result if r["prijmeni"] == "Omluvený"]
+        assert len(excused) == 1
+        assert excused[0]["attendance_pct"] is None
+        assert excused[0]["excused"] == 5
+
+    def test_fully_excused_mp_sorts_last_worst(self):
+        """nulls_last: an undefined rate never tops the 'worst attendance' list."""
+        data = _with_fully_excused_mp()
+        result = compute_attendance(data, top=50, sort="worst")
+        assert result[-1]["prijmeni"] == "Omluvený"
+
+    def test_fully_excused_mp_sorts_last_best(self):
+        """nulls_last: an undefined rate never tops the 'best attendance' list."""
+        data = _with_fully_excused_mp()
+        result = compute_attendance(data, top=50, sort="best")
+        assert result[-1]["prijmeni"] == "Omluvený"
 
     def test_expected_fields(self):
         """Each result should have the expected keys."""

--- a/tests/unit/test_analysis_cache.py
+++ b/tests/unit/test_analysis_cache.py
@@ -1,0 +1,83 @@
+"""Tests for the analysis cache: TTL expiry + LRU eviction (audit fix B8)."""
+
+import time
+
+from pspcz_analyzer.services.analysis_cache import AnalysisCache
+
+
+class TestTTL:
+    def test_hit_within_ttl(self, monkeypatch):
+        """A fresh entry is served without recomputation."""
+        now = [1000.0]
+        monkeypatch.setattr(time, "monotonic", lambda: now[0])
+        cache = AnalysisCache(ttl=60, max_entries=10)
+        calls = 0
+
+        def _compute():
+            nonlocal calls
+            calls += 1
+            return "v"
+
+        assert cache.get_or_compute("k", _compute) == "v"
+        now[0] += 30
+        assert cache.get_or_compute("k", _compute) == "v"
+        assert calls == 1
+
+    def test_miss_after_ttl(self, monkeypatch):
+        """An expired entry is recomputed."""
+        now = [1000.0]
+        monkeypatch.setattr(time, "monotonic", lambda: now[0])
+        cache = AnalysisCache(ttl=60, max_entries=10)
+        calls = 0
+
+        def _compute():
+            nonlocal calls
+            calls += 1
+            return calls
+
+        assert cache.get_or_compute("k", _compute) == 1
+        now[0] += 61
+        assert cache.get_or_compute("k", _compute) == 2
+
+
+class TestLRU:
+    def test_evicts_oldest_beyond_max(self):
+        """Inserting past max_entries drops the least recently used entry."""
+        cache = AnalysisCache(ttl=3600, max_entries=3)
+        for i in range(4):
+            cache.get_or_compute(f"k{i}", lambda i=i: i)
+
+        assert cache.invalidate("k0") == 0  # evicted
+        assert cache.invalidate("k3") == 1  # newest survives
+
+    def test_read_refreshes_recency(self):
+        """A cache hit marks the entry as recently used, protecting it from eviction."""
+        cache = AnalysisCache(ttl=3600, max_entries=3)
+        for i in range(3):
+            cache.get_or_compute(f"k{i}", lambda i=i: i)
+
+        cache.get_or_compute("k0", lambda: "unused")  # touch k0
+        cache.get_or_compute("k3", lambda: 3)  # must evict k1, not k0
+
+        assert cache.invalidate("k1") == 0
+        assert cache.invalidate("k0") == 1
+
+    def test_unbounded_keys_are_capped(self):
+        """User-controlled keys (search strings) cannot grow the cache past the cap."""
+        cache = AnalysisCache(ttl=3600, max_entries=5)
+        for i in range(50):
+            cache.get_or_compute(f"votes:search-{i}", lambda i=i: i)
+
+        assert cache.invalidate() == 5
+
+
+class TestInvalidate:
+    def test_prefix_invalidation(self):
+        """Prefix invalidation removes only matching keys."""
+        cache = AnalysisCache(ttl=3600, max_entries=10)
+        cache.get_or_compute("votes:1:a", lambda: 1)
+        cache.get_or_compute("votes:1:b", lambda: 2)
+        cache.get_or_compute("loyalty:1", lambda: 3)
+
+        assert cache.invalidate("votes:") == 2
+        assert cache.invalidate() == 1

--- a/tests/unit/test_middleware_timeout.py
+++ b/tests/unit/test_middleware_timeout.py
@@ -1,0 +1,51 @@
+"""Tests for run_with_timeout thread-pool behavior (audit fix B10)."""
+
+import threading
+
+import pytest
+from fastapi import HTTPException
+
+from pspcz_analyzer.middleware import run_with_timeout
+
+
+class TestRunWithTimeout:
+    @pytest.mark.asyncio
+    async def test_returns_result(self):
+        """Fast computations return their value."""
+        result = await run_with_timeout(lambda: 42, timeout=5.0, label="test")
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_raises_503_on_timeout(self):
+        """A computation exceeding the timeout surfaces as HTTP 503."""
+        barrier = threading.Event()
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await run_with_timeout(barrier.wait, timeout=0.05, label="slow")
+            assert exc_info.value.status_code == 503
+        finally:
+            barrier.set()
+
+    @pytest.mark.asyncio
+    async def test_timed_out_work_does_not_starve_pool(self):
+        """Two stuck computations must not block subsequent requests.
+
+        Regression: with the old hard-coded max_workers=2, two timed-out
+        (but still running) workers occupied the entire pool and every later
+        computation queued behind them. The pool is now sized with headroom,
+        so the next request gets a worker immediately.
+        """
+        barrier = threading.Event()
+
+        def _block():
+            barrier.wait(timeout=10)
+
+        try:
+            for _ in range(2):
+                with pytest.raises(HTTPException):
+                    await run_with_timeout(_block, timeout=0.05, label="zombie")
+
+            result = await run_with_timeout(lambda: "alive", timeout=5.0, label="next")
+            assert result == "alive"
+        finally:
+            barrier.set()


### PR DESCRIPTION
Audit remediation (part 5): availability fixes for the public frontend — event-loop stalls, compute-pool starvation, and unbounded cache growth.

## Changes

- **B10 — compute pool starvation** (`middleware.py`): `_compute_pool` was hard-coded to `max_workers=2`. Timed-out work keeps occupying its worker (futures can't be cancelled), so two slow computations starved every other analysis request. Pool size is now `COMPUTE_POOL_WORKERS` (env, default `0` → Python's `min(32, cpu_count + 4)`).
- **B8 — votes endpoint + unbounded cache** (`routes/voting.py`, `services/analysis_cache.py`):
  - `votes_api` was the only analysis endpoint **not** wrapped in `run_with_timeout` — a slow free-text search blocked the event loop. It now returns 503 like its siblings.
  - `AnalysisCache` becomes an `OrderedDict` **LRU** capped at `ANALYSIS_CACHE_MAX_ENTRIES` (env, default 512). Keys include user-controlled strings (`search`, `topic`), so the cache previously grew without limit.
- **B9 — watcher event-loop freeze** (`data_reader.py`): `_watch_loop` ran the filesystem scan and period reloads inline on the event loop — a large reload froze all HTTP handling. Both checks now run via `asyncio.to_thread`. (Cross-thread locking of `DataReader` state is a pre-existing pattern tracked as a separate follow-up.)
- **B6 — fully-excused MPs ranked first** (`attendance_service.py`): `active / (total - excused)` = 0/0 = `inf` made a permanently-excused MP rank as having the **best** attendance. The rate is now `null` (`pl.when(denom > 0)…otherwise(None)`) and sorting uses `nulls_last=True`, so undefined rates never top either ranking. The attendance table partial renders an em dash for null rates.
- **Charts** (`routes/charts.py`): seaborn rendering was synchronous CPU work on the event loop — each render helper now runs through `run_with_timeout`, figures are closed in `try/finally` (a render failure used to leak the figure), shared styling extracted to `_style_figure`, and null-attendance rows are filtered before plotting (`barh` can't draw `None`).

## Tests (+13)

- `tests/unit/test_analysis_cache.py` — TTL hit/miss, LRU eviction, read-refreshes-recency, cap under user-controlled keys, prefix invalidation.
- `tests/unit/test_middleware_timeout.py` — result pass-through, 503 on timeout, and the **B10 regression**: two timed-out zombies occupying workers don't block the next request.
- `tests/unit/services/test_attendance.py` — fully-excused MP gets `None`, sorts last under both `worst` and `best`.
- `tests/api/test_api_endpoints.py` — slow votes search returns 503 (B8 regression).

Docs: `COMPUTE_POOL_WORKERS` + `ANALYSIS_CACHE_MAX_ENTRIES` in README env table, `.env.example`, CLAUDE.md.

Gate: **543 passed** (+13), 26 deselected, coverage **57.69%**, `ruff format`/`check` clean, `pyright` 0/0/0.