### PR TITLE
fix(pipelines): one cooperative cancellation model (B7, B12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,10 @@ Background pipeline for third-reading amendment voting analysis. Runs as asyncio
 - **`coalition_service.py`** — Analyzes voting coalitions: which parties voted together per amendment
 - **`cache_manager.py`** — Loads/saves amendment pipeline outputs as Parquet and JSON files
 
+### Pipeline Cancellation (`services/cancellation.py`)
+
+Shared cooperative cancellation for both pipeline services. Pipeline bodies run in worker threads (`asyncio.to_thread`), where `asyncio.Task.cancel()` cannot interrupt them — so each running period owns a `CancellationFlag` that `cancel_period()`/`cancel_all()` flip instantly; pipeline stages call `check()` at every stage boundary and loop top, exiting promptly with `PipelineCancelled` (caught by the service → `CANCELLED` status). Both services also expose `async wait_stopped(timeout)` to drain tasks after `cancel_all()` (hard-cancelling whatever is still running after the timeout); used by the admin stop endpoint, daily refresh, and backend lifespan shutdown.
+
 ### Law Service (`services/law_service.py`)
 
 Provides data for the laws browser. Loads tisk metadata and legislative histories, returns paginated/filterable bill lists. Each law row carries its linked amendment count, `(schuze, bod)` link, and gov/opposition `driver` (via `affiliation`).

--- a/pspcz_analyzer/admin/routes.py
+++ b/pspcz_analyzer/admin/routes.py
@@ -21,10 +21,12 @@ from pspcz_analyzer.admin.pipeline_history import PipelineHistory
 from pspcz_analyzer.config import ADMIN_COOKIE_SECURE, ADMIN_USERNAME, DEFAULT_CACHE_DIR
 from pspcz_analyzer.models.pipeline_progress import (
     AmendmentMode,
+    PeriodStatus,
     PipelineStage,
     TiskMode,
 )
 from pspcz_analyzer.rate_limit import limiter
+from pspcz_analyzer.services.amendments.progress import AmendmentStatus
 from pspcz_analyzer.services.data_service import DataService
 from pspcz_analyzer.services.pipeline_lock import pipeline_lock
 from pspcz_analyzer.services.runtime_config import (
@@ -238,6 +240,30 @@ async def pipeline_status_partial(request: Request) -> HTMLResponse:
     )
 
 
+def _pipeline_was_cancelled(svc: DataService, pipeline_type: str, period: int) -> bool:
+    """Check whether a completed pipeline run ended by cooperative cancellation.
+
+    Cooperatively cancelled runs finish their task normally (the service
+    catches PipelineCancelled and records CANCELLED status), so the
+    outcome must be read from progress state, not the task exception.
+    """
+    match pipeline_type:
+        case "tisk_download" | "tisk_classify" | "tisk_diffs":
+            pp = svc.tisk_pipeline.progress.periods.get(period)
+            return pp is not None and pp.status == PeriodStatus.CANCELLED
+        case "amendment_parse" | "amendment_summarize":
+            ap = svc.amendment_pipeline.progress.get(period)
+            return ap is not None and ap.status == AmendmentStatus.CANCELLED
+        case "full":
+            tisk_pp = svc.tisk_pipeline.progress.periods.get(period)
+            amend_ap = svc.amendment_pipeline.progress.get(period)
+            return (tisk_pp is not None and tisk_pp.status == PeriodStatus.CANCELLED) or (
+                amend_ap is not None and amend_ap.status == AmendmentStatus.CANCELLED
+            )
+        case _:
+            return False
+
+
 async def _monitor_pipeline(
     svc: DataService,
     pipeline_type: str,
@@ -256,8 +282,12 @@ async def _monitor_pipeline(
             amendment_task = svc.amendment_pipeline.get_task(period)
             if amendment_task is not None and not amendment_task.done():
                 await amendment_task
-        history.finish_run(run_data, "success")
-        logger.info("[admin] Pipeline {} finished successfully", label)
+        if _pipeline_was_cancelled(svc, pipeline_type, period):
+            history.finish_run(run_data, "cancelled")
+            logger.info("[admin] Pipeline {} cancelled", label)
+        else:
+            history.finish_run(run_data, "success")
+            logger.info("[admin] Pipeline {} finished successfully", label)
     except asyncio.CancelledError:
         history.finish_run(run_data, "cancelled")
         logger.info("[admin] Pipeline {} cancelled", label)
@@ -357,9 +387,11 @@ async def start_pipeline(
 async def stop_pipeline(request: Request) -> dict:
     """Stop the currently running pipeline.
 
-    Cancels all pipeline tasks. The _monitor_pipeline coroutine catches
-    CancelledError and handles lock release + history recording. If the
-    monitor doesn't release within 2 seconds, force-release as a safety net.
+    Requests cooperative cancellation of all pipeline tasks and waits
+    for them to drain. The _monitor_pipeline coroutine observes the
+    cancellation (status or CancelledError) and handles lock release +
+    history recording. If the monitor doesn't release within 2 seconds,
+    force-release as a safety net.
     """
     svc: DataService = request.app.state.data
 
@@ -367,8 +399,10 @@ async def stop_pipeline(request: Request) -> dict:
         return {"status": "ok", "message": "No pipeline running"}
 
     try:
-        await svc.tisk_pipeline.cancel_all()
+        svc.tisk_pipeline.cancel_all()
         svc.amendment_pipeline.cancel_all()
+        await svc.tisk_pipeline.wait_stopped(timeout=5.0)
+        await svc.amendment_pipeline.wait_stopped(timeout=5.0)
 
         # Yield to event loop so monitor coroutine can process cancellation
         await asyncio.sleep(0)

--- a/pspcz_analyzer/main_backend.py
+++ b/pspcz_analyzer/main_backend.py
@@ -54,9 +54,13 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    # Graceful shutdown
+    # Graceful shutdown: request cooperative cancellation of both
+    # pipelines, then wait for their worker threads to drain
     await refresh_svc.stop()
-    await svc.tisk_pipeline.cancel_all()
+    svc.tisk_pipeline.cancel_all()
+    svc.amendment_pipeline.cancel_all()
+    await svc.tisk_pipeline.wait_stopped()
+    await svc.amendment_pipeline.wait_stopped()
     log_broadcaster.stop()
 
 

--- a/pspcz_analyzer/services/amendments/identifier.py
+++ b/pspcz_analyzer/services/amendments/identifier.py
@@ -6,6 +6,7 @@ third-reading agenda items that likely had amendment votes.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import polars as pl
@@ -27,6 +28,7 @@ def _ensure_tisk_histories(
     period_data: PeriodData,
     cache_dir: Path,
     refresh_active: bool = False,
+    cancel_check: Callable[[], None] | None = None,
 ) -> None:
     """Ensure tisk history data exists and is loaded into memory.
 
@@ -42,6 +44,7 @@ def _ensure_tisk_histories(
         refresh_active: When True, re-scrape histories of active (non-terminal)
             bills so newly third-read bills enter the candidate set during the
             daily refresh.
+        cancel_check: Optional cancellation hook raised between tisky.
     """
     hist_dir = cache_dir / TISKY_META_DIR / str(period) / TISKY_HISTORIE_DIR
     needs_scrape = not hist_dir.exists() or not any(hist_dir.glob("*.json"))
@@ -57,7 +60,7 @@ def _ensure_tisk_histories(
             period,
             len(ct_numbers),
         )
-        scrape_histories_sync(period, ct_numbers, cache_dir)
+        scrape_histories_sync(period, ct_numbers, cache_dir, cancel_check=cancel_check)
 
     # Always load histories into in-memory TiskInfo objects
     cache_mgr = TiskCacheManager(cache_dir)

--- a/pspcz_analyzer/services/amendments/merger.py
+++ b/pspcz_analyzer/services/amendments/merger.py
@@ -6,6 +6,7 @@ and merging PDF-parsed amendments with steno-parsed vote data.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 from loguru import logger
@@ -80,6 +81,7 @@ def _pdf_download_and_parse(
     period: int,
     cache_dir: Path,
     period_data: PeriodData,
+    cancel_check: Callable[[], None] | None = None,
 ) -> tuple[dict[int, list[PdfAmendment]], dict[int, str]]:
     """Download amendment PDFs and parse their structure.
 
@@ -91,6 +93,7 @@ def _pdf_download_and_parse(
         period: Electoral period number.
         cache_dir: Base cache directory.
         period_data: Period data with tisk_lookup for history access.
+        cancel_check: Optional cancellation hook raised between downloads.
 
     Returns:
         Tuple of (ct -> list[PdfAmendment], ct -> raw PDF text).
@@ -108,6 +111,8 @@ def _pdf_download_and_parse(
     unique_cts = sorted({bill.ct for bill in bills})
 
     for ct in unique_cts:
+        if cancel_check:
+            cancel_check()
         history = ct_history.get(ct)
         amendment_ct1 = history.amendment_tisk_ct1 if history else None
         amendment_idd = history.amendment_tisk_idd if history else None

--- a/pspcz_analyzer/services/amendments/pipeline.py
+++ b/pspcz_analyzer/services/amendments/pipeline.py
@@ -47,6 +47,7 @@ from pspcz_analyzer.services.amendments.submitter_resolver import resolve_submit
 from pspcz_analyzer.services.amendments.summarizer import (
     _summarize_amendments,
 )
+from pspcz_analyzer.services.cancellation import CancellationFlag, PipelineCancelled
 
 
 def _run_pipeline_sync(
@@ -57,6 +58,7 @@ def _run_pipeline_sync(
     on_progress: Callable[[int, list[BillAmendmentData]], None] | None = None,
     mode: AmendmentMode = AmendmentMode.FULL,
     refresh_active: bool = False,
+    cancel_check: Callable[[], None] | None = None,
 ) -> list[BillAmendmentData]:
     """Run the amendment pipeline synchronously with mode-based stage selection.
 
@@ -69,6 +71,8 @@ def _run_pipeline_sync(
         mode: Pipeline execution mode.
         refresh_active: When True, re-scrape active bills' histories so newly
             third-read bills are picked up (daily refresh).
+        cancel_check: Optional cancellation hook raised between stages/items;
+            the service passes its per-period CancellationFlag.check here.
 
     Returns:
         List of parsed BillAmendmentData.
@@ -87,7 +91,7 @@ def _run_pipeline_sync(
 
     if run_parse:
         bills, ct_to_pdf_text = _run_parse_stages(
-            period, period_data, cache_dir, progress, on_progress, refresh_active
+            period, period_data, cache_dir, progress, on_progress, refresh_active, cancel_check
         )
     elif run_summarize:
         # Load cached bills from disk
@@ -103,11 +107,20 @@ def _run_pipeline_sync(
         progress.total_items = len(bills)
 
     if run_summarize and bills:
+        if cancel_check:
+            cancel_check()
         # LLM summarization
         progress.stage = AmendmentStage.LLM_SUMMARIZE
         logger.info("[amendment pipeline] Starting LLM summarization for {} bills...", len(bills))
         _summarize_amendments(
-            bills, cache_dir, period, progress, on_progress, period_data, ct_to_pdf_text
+            bills,
+            cache_dir,
+            period,
+            progress,
+            on_progress,
+            period_data,
+            ct_to_pdf_text,
+            cancel_check,
         )
 
         # Final cache
@@ -141,6 +154,7 @@ def _run_parse_stages(
     progress: AmendmentProgress,
     on_progress: Callable[[int, list[BillAmendmentData]], None] | None = None,
     refresh_active: bool = False,
+    cancel_check: Callable[[], None] | None = None,
 ) -> tuple[list[BillAmendmentData], dict[int, str]]:
     """Run parse stages of the amendment pipeline.
 
@@ -160,14 +174,20 @@ def _run_parse_stages(
         cache_dir: Base cache directory.
         progress: Progress tracker (mutated in-place).
         on_progress: Optional callback for UI refresh.
+        cancel_check: Optional cancellation hook raised between stages/items.
 
     Returns:
         Tuple of (list of parsed BillAmendmentData, ct -> PDF text mapping).
     """
+    if cancel_check:
+        cancel_check()
+
     # Stage 0: Ensure tisk histories exist (scrape if needed)
     progress.stage = AmendmentStage.SCRAPE_HISTORIES
     logger.info("[amendment pipeline] Ensuring tisk histories exist...")
-    _ensure_tisk_histories(period, period_data, cache_dir, refresh_active=refresh_active)
+    _ensure_tisk_histories(
+        period, period_data, cache_dir, refresh_active=refresh_active, cancel_check=cancel_check
+    )
 
     # Stage 1: Identify candidates
     progress.stage = AmendmentStage.IDENTIFY
@@ -194,7 +214,7 @@ def _run_parse_stages(
     ct_set = {ct for _, _, ct, _ in candidates}
     temp_bills_for_pdf = [BillAmendmentData(period=period, schuze=0, bod=0, ct=ct) for ct in ct_set]
     pdf_data, ct_to_pdf_text = _pdf_download_and_parse(
-        temp_bills_for_pdf, period, cache_dir, period_data
+        temp_bills_for_pdf, period, cache_dir, period_data, cancel_check
     )
 
     # Stage 3: Download steno and parse
@@ -208,83 +228,88 @@ def _run_parse_stages(
     no_amendments_count = 0
 
     for i, (schuze, bod, ct, nazev) in enumerate(candidates):
-        progress.done_items = i
+        try:
+            if cancel_check:
+                cancel_check()
 
-        # Progress checkpoint every 50 candidates
-        if (i + 1) % 50 == 0:
-            logger.info(
-                "[amendment pipeline] Steno download/parse: {}/{} candidates processed",
-                i + 1,
-                len(candidates),
+            # Progress checkpoint every 50 candidates
+            if (i + 1) % 50 == 0:
+                logger.info(
+                    "[amendment pipeline] Steno download/parse: {}/{} candidates processed",
+                    i + 1,
+                    len(candidates),
+                )
+
+            html, steno_url, failure = find_steno_for_bod(period, schuze, bod, nazev, cache_dir)
+            if html is None:
+                if failure is not None:
+                    failure_counts[failure] += 1
+                logger.debug(
+                    "[amendment pipeline] No steno found for period={} schuze={} bod={} "
+                    "ct={} reason={}",
+                    period,
+                    schuze,
+                    bod,
+                    ct,
+                    failure,
+                )
+                # Without steno, there's no vote linkage — skip.
+                # The tisk pipeline handles raw PDF content separately.
+                continue
+
+            amendments, confidence, warnings = parse_steno_amendments(
+                html, period=period, schuze=schuze, bod=bod
             )
+            if not amendments and not pdf_data.get(ct):
+                no_amendments_count += 1
+                logger.debug(
+                    "[amendment pipeline] Steno found but no amendments parsed for "
+                    "period={} schuze={} bod={} ct={}",
+                    period,
+                    schuze,
+                    bod,
+                    ct,
+                )
+                continue
 
-        html, steno_url, failure = find_steno_for_bod(period, schuze, bod, nazev, cache_dir)
-        if html is None:
-            if failure is not None:
-                failure_counts[failure] += 1
-            logger.debug(
-                "[amendment pipeline] No steno found for period={} schuze={} bod={} ct={} reason={}",
-                period,
-                schuze,
-                bod,
-                ct,
-                failure,
+            # Cross-validate against official vote data
+            schuze_bod_votes = period_data.votes.filter(
+                (pl.col("schuze") == schuze) & (pl.col("bod") == bod)
             )
-            # Without steno, there's no vote linkage — skip.
-            # The tisk pipeline handles raw PDF content separately.
-            continue
+            if amendments:
+                amendments, xval_warnings = cross_validate_amendments(
+                    amendments, schuze_bod_votes, schuze, bod
+                )
+                warnings.extend(xval_warnings)
 
-        amendments, confidence, warnings = parse_steno_amendments(
-            html, period=period, schuze=schuze, bod=bod
-        )
-        if not amendments and not pdf_data.get(ct):
-            no_amendments_count += 1
-            logger.debug(
-                "[amendment pipeline] Steno found but no amendments parsed for "
-                "period={} schuze={} bod={} ct={}",
-                period,
-                schuze,
-                bod,
-                ct,
+            # Separate final vote from amendments
+            regular = [a for a in amendments if not a.is_final_vote]
+            final = next((a for a in amendments if a.is_final_vote), None)
+
+            bill = BillAmendmentData(
+                period=period,
+                schuze=schuze,
+                bod=bod,
+                ct=ct,
+                tisk_nazev=nazev,
+                steno_url=steno_url,
+                amendments=regular,
+                final_vote=final,
+                parse_confidence=confidence,
+                parse_warnings=warnings,
+                amendment_tisk_ct1=next(
+                    (b.amendment_tisk_ct1 for b in temp_bills_for_pdf if b.ct == ct), None
+                ),
+                amendment_tisk_idd=next(
+                    (b.amendment_tisk_idd for b in temp_bills_for_pdf if b.ct == ct), None
+                ),
             )
-            continue
-
-        # Cross-validate against official vote data
-        schuze_bod_votes = period_data.votes.filter(
-            (pl.col("schuze") == schuze) & (pl.col("bod") == bod)
-        )
-        if amendments:
-            amendments, xval_warnings = cross_validate_amendments(
-                amendments, schuze_bod_votes, schuze, bod
-            )
-            warnings.extend(xval_warnings)
-
-        # Separate final vote from amendments
-        regular = [a for a in amendments if not a.is_final_vote]
-        final = next((a for a in amendments if a.is_final_vote), None)
-
-        bill = BillAmendmentData(
-            period=period,
-            schuze=schuze,
-            bod=bod,
-            ct=ct,
-            tisk_nazev=nazev,
-            steno_url=steno_url,
-            amendments=regular,
-            final_vote=final,
-            parse_confidence=confidence,
-            parse_warnings=warnings,
-            amendment_tisk_ct1=next(
-                (b.amendment_tisk_ct1 for b in temp_bills_for_pdf if b.ct == ct), None
-            ),
-            amendment_tisk_idd=next(
-                (b.amendment_tisk_idd for b in temp_bills_for_pdf if b.ct == ct), None
-            ),
-        )
-        bills.append(bill)
-        progress.bills_parsed += 1
-
-    progress.done_items = len(candidates)
+            bills.append(bill)
+            progress.bills_parsed += 1
+        finally:
+            # Count the candidate as done regardless of outcome (previously
+            # set to `i` before processing — the bar lagged one item behind).
+            progress.done_items = i + 1
 
     failure_detail = ", ".join(f"{r.value}={c}" for r, c in failure_counts.most_common())
     logger.info(
@@ -311,6 +336,9 @@ def _run_parse_stages(
         with_proposer,
         total_amendments,
     )
+
+    if cancel_check:
+        cancel_check()
 
     # Stage 4: Merge PDF and steno data
     progress.stage = AmendmentStage.MERGE
@@ -360,6 +388,7 @@ class AmendmentPipelineService:
     cache_dir: Path
     _progress: dict[int, AmendmentProgress] = field(default_factory=dict)
     _tasks: dict[int, asyncio.Task] = field(default_factory=dict)  # type: ignore[type-arg]
+    _flags: dict[int, CancellationFlag] = field(default_factory=dict)
 
     @property
     def progress(self) -> dict[int, AmendmentProgress]:
@@ -392,6 +421,8 @@ class AmendmentPipelineService:
 
         prog = AmendmentProgress(status=AmendmentStatus.RUNNING)
         self._progress[period] = prog
+        flag = CancellationFlag(period)
+        self._flags[period] = flag
 
         async def _run() -> None:
             try:
@@ -404,12 +435,17 @@ class AmendmentPipelineService:
                     on_progress,
                     mode,
                     refresh_active,
+                    flag.check,
                 )
                 prog.status = AmendmentStatus.COMPLETED
                 prog.stage = AmendmentStage.COMPLETED
                 if on_complete:
                     on_complete(period, bills)
+            except PipelineCancelled:
+                prog.status = AmendmentStatus.CANCELLED
+                logger.info("[amendment pipeline] Cancelled for period {}", period)
             except asyncio.CancelledError:
+                prog.status = AmendmentStatus.CANCELLED
                 logger.info("[amendment pipeline] Cancelled for period {}", period)
                 raise
             except Exception:
@@ -418,8 +454,12 @@ class AmendmentPipelineService:
                 logger.opt(exception=True).error(
                     "[amendment pipeline] Failed for period {}", period
                 )
+            finally:
+                self._flags.pop(period, None)
 
-        self._tasks[period] = asyncio.create_task(_run())
+        task = asyncio.create_task(_run())
+        task.add_done_callback(lambda t: self._on_task_done(period, t))
+        self._tasks[period] = task
 
     def is_running(self, period: int) -> bool:
         """Check if the pipeline is currently running for a period."""
@@ -433,24 +473,62 @@ class AmendmentPipelineService:
             return task
         return None
 
+    def _on_task_done(self, period: int, task: asyncio.Task) -> None:
+        """Prune a finished period's task + flag.
+
+        Only removes the dict entries if this task is still the current
+        one — a restart for the same period may have replaced them
+        before this done-callback fired.
+        """
+        if self._tasks.get(period) is task:
+            self._tasks.pop(period, None)
+            self._flags.pop(period, None)
+
     def cancel_period(self, period: int) -> bool:
         """Cancel the amendment pipeline for a single period.
 
-        Each period runs as an independent asyncio.Task, so we can just
-        cancel it directly.
+        Flips the period's cancellation flag; the worker thread stops
+        cooperatively at its next checkpoint. (task.cancel() alone cannot
+        interrupt work running inside asyncio.to_thread — it only
+        releases the awaiting coroutine.)
 
-        Returns True if a task was found and cancelled.
+        Returns True if a cancellation was requested.
         """
-        task = self._tasks.get(period)
-        if task is None or task.done():
+        flag = self._flags.get(period)
+        if flag is None or not self.is_running(period):
             return False
-        task.cancel()
-        logger.info("[amendment pipeline] Cancelling for period {}", period)
+        flag.cancel()
+        logger.info("[amendment pipeline] Cancellation requested for period {}", period)
         return True
 
     def cancel_all(self) -> None:
-        """Cancel all running pipeline tasks."""
-        for period, task in self._tasks.items():
-            if not task.done():
-                task.cancel()
-                logger.info("[amendment pipeline] Cancelling for period {}", period)
+        """Request cancellation of all running amendment pipelines.
+
+        Flips every period flag; running stages stop cooperatively at
+        their next checkpoint. Await wait_stopped() to let tasks drain.
+        """
+        for flag in self._flags.values():
+            flag.cancel()
+        logger.info("[amendment pipeline] Cancellation requested for all periods")
+
+    async def wait_stopped(self, timeout: float = 10.0) -> None:
+        """Wait for running tasks to drain after cancel_all().
+
+        Tasks still running after *timeout* are hard-cancelled — that
+        releases the event-loop side immediately; worker threads exit
+        at their next cancellation checkpoint.
+        """
+        tasks = [t for t in self._tasks.values() if not t.done()]
+        if tasks:
+            _, pending = await asyncio.wait(tasks, timeout=timeout)
+            if pending:
+                logger.warning(
+                    "[amendment pipeline] {} tasks still draining after {}s — forcing cancellation",
+                    len(pending),
+                    timeout,
+                )
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+        self._tasks.clear()
+        self._flags.clear()

--- a/pspcz_analyzer/services/amendments/progress.py
+++ b/pspcz_analyzer/services/amendments/progress.py
@@ -33,6 +33,7 @@ class AmendmentStatus(StrEnum):
     IDLE = "idle"
     RUNNING = "running"
     COMPLETED = "completed"
+    CANCELLED = "cancelled"
     FAILED = "failed"
 
 

--- a/pspcz_analyzer/services/amendments/summarizer.py
+++ b/pspcz_analyzer/services/amendments/summarizer.py
@@ -221,6 +221,7 @@ def _summarize_amendments(
     on_progress: Callable[[int, list[BillAmendmentData]], None] | None = None,
     period_data: PeriodData | None = None,
     ct_to_pdf_text: dict[int, str] | None = None,
+    cancel_check: Callable[[], None] | None = None,
 ) -> None:
     """Generate bill summaries (reusing tisk summaries) and per-amendment LLM summaries.
 
@@ -236,6 +237,7 @@ def _summarize_amendments(
         on_progress: Optional callback(period, bills) for incremental UI refresh.
         period_data: Loaded period data for tisk summary lookup.
         ct_to_pdf_text: Mapping of ct -> raw PDF text (transient, not cached).
+        cancel_check: Optional cancellation hook raised between bills.
     """
     llm = create_llm_client()
     if not llm.is_available():
@@ -260,6 +262,8 @@ def _summarize_amendments(
     llm_generated = 0
 
     for i, bill in enumerate(bills):
+        if cancel_check:
+            cancel_check()
         # Use transient PDF text dict or fall back to per-amendment text
         text = pdf_text_map.get(bill.ct, "") or next(
             (a.amendment_text for a in bill.amendments if a.amendment_text), ""

--- a/pspcz_analyzer/services/cancellation.py
+++ b/pspcz_analyzer/services/cancellation.py
@@ -1,0 +1,64 @@
+"""Cooperative cancellation primitives for background pipelines.
+
+Pipeline bodies run in worker threads via ``asyncio.to_thread``, where
+``asyncio.Task.cancel()`` cannot interrupt them — the awaiting coroutine
+is released, but the thread itself keeps running to completion. Instead,
+each running period owns a :class:`CancellationFlag`: HTTP handlers flip
+it instantly, and pipeline code calls :meth:`CancellationFlag.check` at
+every stage boundary and loop top, exiting promptly with
+:class:`PipelineCancelled`.
+"""
+
+import threading
+
+
+class PipelineCancelled(Exception):
+    """Raised inside a pipeline when its period has been cancelled."""
+
+    def __init__(self, period: int) -> None:
+        """Store the cancelled period on the exception.
+
+        Args:
+            period: Electoral period whose pipeline was cancelled.
+        """
+        self.period = period
+        super().__init__(f"Pipeline for period {period} cancelled")
+
+
+class CancellationFlag:
+    """Thread-safe cooperative cancellation flag for one pipeline period.
+
+    ``cancel()`` may be called from any thread (typically an HTTP
+    handler on the event loop); ``is_cancelled()`` / ``check()`` are
+    read from worker threads at stage boundaries. The flag is one-shot
+    and single-period: pipeline services create a fresh flag per run.
+    """
+
+    def __init__(self, period: int) -> None:
+        """Create an uncancelled flag for a period.
+
+        Args:
+            period: Electoral period this flag governs.
+        """
+        self.period = period
+        self._cancelled = False
+        self._lock = threading.Lock()
+
+    def cancel(self) -> None:
+        """Request cancellation. Idempotent and thread-safe."""
+        with self._lock:
+            self._cancelled = True
+
+    def is_cancelled(self) -> bool:
+        """Whether cancellation has been requested."""
+        return self._cancelled
+
+    def check(self) -> None:
+        """Raise PipelineCancelled if cancellation was requested.
+
+        Called at stage boundaries and loop tops inside worker threads.
+        Reads without the lock — bool reads are atomic under the GIL
+        and this sits on the hot path of long-running loops.
+        """
+        if self._cancelled:
+            raise PipelineCancelled(self.period)

--- a/pspcz_analyzer/services/data_service.py
+++ b/pspcz_analyzer/services/data_service.py
@@ -311,9 +311,12 @@ class DataService(DataReader):
         async with self._refresh_lock:
             logger.info("[daily-refresh] Starting full data refresh ...")
 
-            # 1. Cancel tisk and amendment pipelines
-            await self.tisk_pipeline.cancel_all()
+            # 1. Cancel tisk and amendment pipelines (cooperative), then
+            #    wait for the worker threads to stop at their next checkpoint
+            self.tisk_pipeline.cancel_all()
             self.amendment_pipeline.cancel_all()
+            await self.tisk_pipeline.wait_stopped()
+            await self.amendment_pipeline.wait_stopped()
 
             # 2. Re-download and reload shared tables
             try:

--- a/pspcz_analyzer/services/tisk/pipeline.py
+++ b/pspcz_analyzer/services/tisk/pipeline.py
@@ -28,6 +28,7 @@ from pspcz_analyzer.models.pipeline_progress import (
     StageProgress,
     TiskMode,
 )
+from pspcz_analyzer.services.cancellation import CancellationFlag, PipelineCancelled
 from pspcz_analyzer.services.llm import deserialize_topics
 from pspcz_analyzer.services.tisk.classifier import classify_and_save, consolidate_topics
 from pspcz_analyzer.services.tisk.downloader_pipeline import process_period_sync
@@ -41,14 +42,6 @@ from pspcz_analyzer.services.tisk.version_service import (
 )
 
 
-class PeriodCancelled(Exception):
-    """Raised when a running period is cancelled at a stage boundary."""
-
-    def __init__(self, period: int) -> None:
-        self.period = period
-        super().__init__(f"Period {period} cancelled")
-
-
 class TiskPipelineService:
     """Manages background tisk processing for loaded periods."""
 
@@ -56,10 +49,12 @@ class TiskPipelineService:
         self.cache_dir = cache_dir
         self._tasks: dict[int, asyncio.Task] = {}
         self._all_task: asyncio.Task | None = None
+        self._flags: dict[int, CancellationFlag] = {}
         self._progress = PipelineProgress()
         self._progress_lock = threading.Lock()
         self._skip_periods: set[int] = set()
-        self._cancel_current: int | None = None
+        # Set by cancel_all(); makes flags created afterwards start
+        # pre-cancelled, so runs started mid-shutdown die immediately.
         self._cancel_all_flag: bool = False
 
     @property
@@ -90,6 +85,7 @@ class TiskPipelineService:
             self._run_period(period, ct_numbers, on_complete, mode, refresh_active),
             name=f"tisk-pipeline-{period}",
         )
+        task.add_done_callback(lambda t: self._on_period_done(period, t))
         self._tasks[period] = task
         logger.info(
             "[tisk pipeline] Started background processing for period {} ({} tisky, mode={})",
@@ -121,6 +117,7 @@ class TiskPipelineService:
             self._run_all_periods(period_ct_numbers, on_complete, mode),
             name="tisk-pipeline-all",
         )
+        self._all_task.add_done_callback(self._on_all_task_done)
         total_tisky = sum(len(cts) for _, cts in period_ct_numbers)
         logger.info(
             "[tisk pipeline] Started sequential processing of {} periods ({} tisky total, mode={})",
@@ -129,10 +126,41 @@ class TiskPipelineService:
             mode.value,
         )
 
+    def _flag_for(self, period: int) -> CancellationFlag:
+        """Get or create the cancellation flag for a period.
+
+        Reusing an existing flag matters: a cancel request that arrives
+        between start_period() and the task body starting must still be
+        honored by the run that follows.
+        """
+        flag = self._flags.get(period)
+        if flag is None:
+            flag = CancellationFlag(period)
+            if self._cancel_all_flag:
+                flag.cancel()
+            self._flags[period] = flag
+        return flag
+
+    def _on_period_done(self, period: int, task: asyncio.Task) -> None:
+        """Prune a finished period's task + flag.
+
+        Only removes the dict entries if this task is still the current
+        one — a restart for the same period may have replaced them
+        before this done-callback fired.
+        """
+        if self._tasks.get(period) is task:
+            self._tasks.pop(period, None)
+            self._flags.pop(period, None)
+
+    def _on_all_task_done(self, task: asyncio.Task) -> None:
+        """Clear _all_task once the sequential run finishes."""
+        if self._all_task is task:
+            self._all_task = None
+
     def _init_progress(self, period_ct_numbers: list[tuple[int, list[int]]]) -> None:
         """Initialize progress tracking for a new pipeline run."""
         self._skip_periods.clear()
-        self._cancel_current = None
+        self._cancel_all_flag = False
         with self._progress_lock:
             self._progress = PipelineProgress(
                 running=True,
@@ -179,30 +207,20 @@ class TiskPipelineService:
                 pp.current_stage = None
 
     def _check_period_cancelled(self, period: int) -> None:
-        """Check if the current period was cancelled and raise if so.
+        """Raise PipelineCancelled if the period was cancelled.
 
-        Called between stages in _run_period(). Safe to call from the event
-        loop thread — _cancel_current is only written from HTTP handlers
-        and read at await boundaries.
+        Called between stages in _run_period() on the event loop thread.
         """
-        if self._cancel_all_flag or self._cancel_current == period:
-            self._cancel_current = None
-            raise PeriodCancelled(period)
+        self._flag_for(period).check()
 
     def _make_cancel_check(self, period: int) -> Callable[[], None]:
         """Create a cancellation checker for use inside worker threads.
 
-        Returns a closure that reads _cancel_current and raises
-        PeriodCancelled if the given period was cancelled. Safe to call
-        from worker threads — single-variable reads are atomic under the GIL.
+        Returns the period flag's bound check(), which raises
+        PipelineCancelled once cancellation is requested. Safe to call
+        from worker threads — flag reads are atomic under the GIL.
         """
-
-        def check() -> None:
-            if self._cancel_all_flag or self._cancel_current == period:
-                self._cancel_current = None
-                raise PeriodCancelled(period)
-
-        return check
+        return self._flag_for(period).check
 
     def remove_pending_period(self, period: int) -> bool:
         """Remove a pending period from the queue before it starts.
@@ -223,31 +241,39 @@ class TiskPipelineService:
         """Cancel a single period — pending or in-progress.
 
         For pending periods, marks SKIPPED immediately.
-        For in-progress periods, sets _cancel_current flag checked at next
-        stage boundary.
+        For in-progress periods, flips the period's cancellation flag;
+        the run stops cooperatively at its next checkpoint.
 
         Returns True if a cancellation action was taken.
         """
         with self._progress_lock:
             pp = self._progress.periods.get(period)
-            if pp is None:
-                return False
-            match pp.status:
-                case PeriodStatus.PENDING:
-                    pp.status = PeriodStatus.SKIPPED
-                    pp.current_stage = None
-                    self._skip_periods.add(period)
-                    logger.info("[tisk pipeline] Removed pending period {}", period)
-                    return True
-                case PeriodStatus.IN_PROGRESS:
-                    self._cancel_current = period
-                    logger.info(
-                        "[tisk pipeline] Cancellation requested for running period {}",
-                        period,
-                    )
-                    return True
-                case _:
-                    return False
+            if pp is not None:
+                match pp.status:
+                    case PeriodStatus.PENDING:
+                        pp.status = PeriodStatus.SKIPPED
+                        pp.current_stage = None
+                        self._skip_periods.add(period)
+                        logger.info("[tisk pipeline] Removed pending period {}", period)
+                        return True
+                    case PeriodStatus.IN_PROGRESS:
+                        self._flag_for(period).cancel()
+                        logger.info(
+                            "[tisk pipeline] Cancellation requested for running period {}",
+                            period,
+                        )
+                        return True
+                    case _:
+                        pass
+        # Runs without progress tracking (direct start_period): cancel via flag
+        if self.is_running(period):
+            self._flag_for(period).cancel()
+            logger.info(
+                "[tisk pipeline] Cancellation requested for running period {}",
+                period,
+            )
+            return True
+        return False
 
     async def _run_all_periods(
         self,
@@ -258,6 +284,10 @@ class TiskPipelineService:
         """Process periods one by one, sequentially."""
         try:
             for period, ct_numbers in period_ct_numbers:
+                # cancel_all() marks every remaining queued period cancelled
+                if self._cancel_all_flag:
+                    self._set_period_status(period, PeriodStatus.CANCELLED)
+                    continue
                 # Check if period was removed from queue
                 if period in self._skip_periods:
                     self._skip_periods.discard(period)
@@ -274,12 +304,7 @@ class TiskPipelineService:
                     mode.value,
                 )
                 self._set_period_status(period, PeriodStatus.IN_PROGRESS)
-                try:
-                    await self._run_period(period, ct_numbers, on_complete, mode)
-                except PeriodCancelled:
-                    self._set_period_status(period, PeriodStatus.CANCELLED)
-                    logger.info("[tisk pipeline] Period {} cancelled, continuing to next", period)
-                    continue
+                await self._run_period(period, ct_numbers, on_complete, mode)
             completed = sum(
                 1 for pp in self._progress.periods.values() if pp.status == PeriodStatus.COMPLETED
             )
@@ -352,7 +377,7 @@ class TiskPipelineService:
     ) -> None:
         """Run pipeline stages based on mode. Runs heavy work in threads."""
         n = len(ct_numbers)
-        cancel_check = self._make_cancel_check(period)
+        cancel_check = self._flag_for(period).check
         active_cts: set[int] | None = None
         try:
             histories: dict = {}
@@ -520,14 +545,17 @@ class TiskPipelineService:
                     subtisk_map,
                     version_diffs,
                 )
-        except PeriodCancelled:
-            raise
+        except PipelineCancelled:
+            self._set_period_status(period, PeriodStatus.CANCELLED)
+            logger.info("[tisk pipeline] Period {} cancelled", period)
         except asyncio.CancelledError:
             logger.info("[tisk pipeline] Pipeline cancelled for period {}", period)
             raise
         except Exception:
             self._set_period_status(period, PeriodStatus.FAILED)
             logger.opt(exception=True).error("[tisk pipeline] Failed for period {}", period)
+        finally:
+            self._flags.pop(period, None)
 
     def is_running(self, period: int) -> bool:
         """Check whether the pipeline is running for a given period."""
@@ -541,35 +569,46 @@ class TiskPipelineService:
             return task
         return None
 
-    async def cancel_all(self) -> None:
-        """Cancel all running pipeline tasks and wait for them to finish."""
-        self._skip_periods.clear()
-        self._cancel_current = None
+    def cancel_all(self) -> None:
+        """Request cancellation of all running pipelines.
+
+        Flips every period flag (and pre-cancels any flag created
+        afterwards) — running stages stop cooperatively at their next
+        checkpoint, and queued periods are skipped by the sequential
+        loop. Await wait_stopped() to let the tasks drain.
+        """
         self._cancel_all_flag = True
+        for flag in self._flags.values():
+            flag.cancel()
+        logger.info("[tisk pipeline] Cancellation requested for all pipelines")
 
-        tasks_to_cancel: list[asyncio.Task] = []
+    async def wait_stopped(self, timeout: float = 10.0) -> None:
+        """Wait for pipeline tasks to drain after cancel_all().
 
+        Tasks still running after *timeout* are hard-cancelled — that
+        releases the event-loop side immediately; worker threads exit
+        at their next cancellation checkpoint. Clears task/flag state
+        and marks the run as no longer running.
+        """
+        tasks = [t for t in self._tasks.values() if not t.done()]
         if self._all_task is not None and not self._all_task.done():
-            self._all_task.cancel()
-            tasks_to_cancel.append(self._all_task)
+            tasks.append(self._all_task)
+        if tasks:
+            _, pending = await asyncio.wait(tasks, timeout=timeout)
+            if pending:
+                logger.warning(
+                    "[tisk pipeline] {} tasks still draining after {}s — forcing cancellation",
+                    len(pending),
+                    timeout,
+                )
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
 
-        for task in self._tasks.values():
-            if not task.done():
-                task.cancel()
-                tasks_to_cancel.append(task)
-
-        if tasks_to_cancel:
-            logger.info("[tisk pipeline] Cancelling {} tasks ...", len(tasks_to_cancel))
-            await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
-            logger.info("[tisk pipeline] All tasks cancelled")
-
-        # Grace period: keep _cancel_all_flag set so thread pool threads
-        # still running their current LLM call will notice it at the next
-        # cancel_check() and exit cleanly.
-        await asyncio.sleep(0.5)
-        self._cancel_all_flag = False
         self._tasks.clear()
+        self._flags.clear()
         self._all_task = None
+        self._cancel_all_flag = False
 
         with self._progress_lock:
             self._progress.running = False

--- a/tests/unit/services/test_pipeline_cancellation.py
+++ b/tests/unit/services/test_pipeline_cancellation.py
@@ -1,0 +1,218 @@
+"""Cancellation behavior for the amendment + tisk pipeline services.
+
+Covers the cooperative flag model: cancel requests flip a per-period
+CancellationFlag, worker threads stop at their next checkpoint, and the
+services record CANCELLED status. Regression for the amendment pipeline
+cancel being a no-op (task.cancel() cannot interrupt asyncio.to_thread).
+"""
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+
+from pspcz_analyzer.models.amendment_models import BillAmendmentData
+from pspcz_analyzer.models.pipeline_progress import (
+    AmendmentMode,
+    PeriodProgress,
+    PeriodStatus,
+)
+from pspcz_analyzer.services.amendments import merger, summarizer
+from pspcz_analyzer.services.amendments import pipeline as amendment_pipeline
+from pspcz_analyzer.services.amendments.progress import (
+    AmendmentProgress,
+    AmendmentStatus,
+)
+from pspcz_analyzer.services.cancellation import CancellationFlag, PipelineCancelled
+from pspcz_analyzer.services.tisk.pipeline import TiskPipelineService
+from tests.fixtures.sample_data import make_period_data
+
+_CANDIDATES = [(1, 1, 100, "t1"), (1, 2, 101, "t2"), (1, 3, 102, "t3")]
+
+
+def _make_blocking_find_steno(
+    calls: list[tuple[int, int]],
+    entered: threading.Event,
+    release: threading.Event,
+):
+    """Fake find_steno_for_bod: blocks on the first call until released."""
+
+    def fake_find_steno(
+        period: int, schuze: int, bod: int, nazev: str, cache_dir: Path
+    ) -> tuple[None, None, None]:
+        calls.append((schuze, bod))
+        if len(calls) == 1:
+            entered.set()
+            if not release.wait(10):
+                raise RuntimeError("test timed out waiting for cancellation")
+        return None, None, None
+
+    return fake_find_steno
+
+
+class TestAmendmentPipelineCancellation:
+    @pytest.mark.asyncio
+    async def test_cancel_mid_run_stops_steno_downloads(self, tmp_path, monkeypatch):
+        """Cancel while blocked on candidate 1 → CANCELLED, no further downloads."""
+        calls: list[tuple[int, int]] = []
+        entered = threading.Event()
+        release = threading.Event()
+
+        monkeypatch.setattr(amendment_pipeline, "_ensure_tisk_histories", lambda *a, **k: None)
+        monkeypatch.setattr(
+            amendment_pipeline, "_identify_third_reading_bods", lambda _pd: _CANDIDATES
+        )
+        monkeypatch.setattr(amendment_pipeline, "_pdf_download_and_parse", lambda *a, **k: ({}, {}))
+        monkeypatch.setattr(
+            amendment_pipeline,
+            "find_steno_for_bod",
+            _make_blocking_find_steno(calls, entered, release),
+        )
+        monkeypatch.setattr(amendment_pipeline, "save_amendments", lambda *a, **k: None)
+
+        svc = amendment_pipeline.AmendmentPipelineService(cache_dir=tmp_path)
+        svc.start_period(9, make_period_data(), mode=AmendmentMode.PARSE)
+
+        # Wait until the worker is blocked inside the first steno lookup
+        assert await asyncio.to_thread(entered.wait, 10)
+        assert svc.cancel_period(9) is True
+        release.set()
+
+        await svc.wait_stopped(timeout=10)
+
+        assert svc.progress[9].status == AmendmentStatus.CANCELLED
+        assert len(calls) == 1, "steno download continued after cancellation"
+
+    @pytest.mark.asyncio
+    async def test_completed_run_prunes_task_and_flag(self, tmp_path, monkeypatch):
+        """A normal run clears _tasks/_flags when its task finishes."""
+        monkeypatch.setattr(amendment_pipeline, "_ensure_tisk_histories", lambda *a, **k: None)
+        monkeypatch.setattr(amendment_pipeline, "_identify_third_reading_bods", lambda _pd: [])
+        monkeypatch.setattr(amendment_pipeline, "save_amendments", lambda *a, **k: None)
+
+        svc = amendment_pipeline.AmendmentPipelineService(cache_dir=tmp_path)
+        svc.start_period(9, make_period_data(), mode=AmendmentMode.PARSE)
+
+        await svc.wait_stopped(timeout=10)
+
+        assert svc.progress[9].status == AmendmentStatus.COMPLETED
+        assert svc._tasks == {}
+        assert svc._flags == {}
+
+    def test_cancel_period_not_running_returns_false(self, tmp_path):
+        svc = amendment_pipeline.AmendmentPipelineService(cache_dir=tmp_path)
+        assert svc.cancel_period(9) is False
+
+    def test_run_pipeline_sync_raises_on_precancelled_flag(self, tmp_path, monkeypatch):
+        """A pre-cancelled flag stops the run before any stage executes."""
+        ensure_calls: list[int] = []
+        monkeypatch.setattr(
+            amendment_pipeline,
+            "_ensure_tisk_histories",
+            lambda *a, **k: ensure_calls.append(1),
+        )
+
+        flag = CancellationFlag(9)
+        flag.cancel()
+        prog = AmendmentProgress(status=AmendmentStatus.RUNNING)
+
+        with pytest.raises(PipelineCancelled):
+            amendment_pipeline._run_pipeline_sync(
+                9,
+                make_period_data(),
+                tmp_path,
+                prog,
+                mode=AmendmentMode.PARSE,
+                cancel_check=flag.check,
+            )
+        assert ensure_calls == []
+
+    def test_pdf_download_loop_respects_cancel(self, tmp_path, monkeypatch):
+        downloads: list[int] = []
+        monkeypatch.setattr(merger, "_download_amendment_pdf", lambda *a: downloads.append(a[1]))
+
+        flag = CancellationFlag(9)
+        flag.cancel()
+        bills = [BillAmendmentData(period=9, schuze=1, bod=1, ct=100)]
+
+        with pytest.raises(PipelineCancelled):
+            merger._pdf_download_and_parse(bills, 9, tmp_path, make_period_data(), flag.check)
+        assert downloads == []
+
+    def test_summarize_loop_respects_cancel(self, tmp_path, monkeypatch):
+        class _StubLLM:
+            provider = "stub"
+            model = "stub-model"
+
+            def is_available(self) -> bool:
+                return True
+
+        monkeypatch.setattr(summarizer, "create_llm_client", lambda: _StubLLM())
+
+        flag = CancellationFlag(9)
+        flag.cancel()
+        bills = [BillAmendmentData(period=9, schuze=1, bod=1, ct=100)]
+        prog = AmendmentProgress(status=AmendmentStatus.RUNNING)
+
+        with pytest.raises(PipelineCancelled):
+            summarizer._summarize_amendments(bills, tmp_path, 9, prog, cancel_check=flag.check)
+        assert prog.done_items == 0
+
+
+class TestTiskPipelineCancellation:
+    def test_in_progress_sets_flag_and_check_raises(self):
+        svc = TiskPipelineService()
+        pp = PeriodProgress(period=9, tisky_count=3)
+        pp.status = PeriodStatus.IN_PROGRESS
+        svc.progress.periods[9] = pp
+
+        assert svc.cancel_period(9) is True
+        with pytest.raises(PipelineCancelled):
+            svc._make_cancel_check(9)()
+        with pytest.raises(PipelineCancelled):
+            svc._check_period_cancelled(9)
+
+    def test_pending_marks_skipped(self):
+        svc = TiskPipelineService()
+        pp = PeriodProgress(period=9)  # default PENDING
+        svc.progress.periods[9] = pp
+
+        assert svc.cancel_period(9) is True
+        assert pp.status == PeriodStatus.SKIPPED
+        assert 9 in svc._skip_periods
+
+    def test_completed_period_returns_false(self):
+        svc = TiskPipelineService()
+        pp = PeriodProgress(period=9)
+        pp.status = PeriodStatus.COMPLETED
+        svc.progress.periods[9] = pp
+        assert svc.cancel_period(9) is False
+
+    def test_unknown_period_returns_false(self):
+        assert TiskPipelineService().cancel_period(9) is False
+
+    def test_cancel_all_flags_existing_and_new_periods(self):
+        svc = TiskPipelineService()
+        running_flag = svc._flag_for(9)
+
+        svc.cancel_all()
+
+        assert running_flag.is_cancelled()
+        # Flags created after cancel_all start pre-cancelled, so runs
+        # started mid-shutdown die at their first checkpoint.
+        assert svc._flag_for(10).is_cancelled()
+
+    @pytest.mark.asyncio
+    async def test_wait_stopped_clears_state(self):
+        svc = TiskPipelineService()
+        svc._flag_for(9)
+        svc.cancel_all()
+
+        await svc.wait_stopped(timeout=0.1)
+
+        assert svc._flags == {}
+        assert svc._tasks == {}
+        assert svc.progress.running is False
+        # After the drain, a fresh run is no longer pre-cancelled
+        assert not svc._flag_for(9).is_cancelled()

--- a/tests/unit/test_cancellation.py
+++ b/tests/unit/test_cancellation.py
@@ -1,0 +1,47 @@
+"""Tests for the cooperative cancellation primitives."""
+
+import threading
+from collections.abc import Callable
+
+import pytest
+
+from pspcz_analyzer.services.cancellation import CancellationFlag, PipelineCancelled
+
+
+class TestCancellationFlag:
+    def test_check_passes_when_not_cancelled(self):
+        CancellationFlag(9).check()  # must not raise
+
+    def test_cancel_sets_is_cancelled(self):
+        flag = CancellationFlag(9)
+        assert not flag.is_cancelled()
+        flag.cancel()
+        assert flag.is_cancelled()
+
+    def test_check_raises_after_cancel(self):
+        flag = CancellationFlag(9)
+        flag.cancel()
+        with pytest.raises(PipelineCancelled, match="period 9") as exc_info:
+            flag.check()
+        assert exc_info.value.period == 9
+
+    def test_cancel_is_idempotent(self):
+        flag = CancellationFlag(9)
+        flag.cancel()
+        flag.cancel()
+        assert flag.is_cancelled()
+
+    def test_cancel_from_another_thread_is_visible(self):
+        flag = CancellationFlag(9)
+        thread = threading.Thread(target=flag.cancel)
+        thread.start()
+        thread.join(timeout=5)
+        assert flag.is_cancelled()
+
+    def test_check_is_usable_as_plain_callable(self):
+        flag = CancellationFlag(9)
+        fn: Callable[[], None] = flag.check
+        fn()  # uncancelled — passes
+        flag.cancel()
+        with pytest.raises(PipelineCancelled):
+            fn()


### PR DESCRIPTION
Audit remediation PR6 (from the professionalization plan). Stacks on merged #71.

## Problem

**B7 — amendment cancel was a total no-op.** `AmendmentPipelineService.cancel_period` called `task.cancel()`, but the entire pipeline body runs in `asyncio.to_thread`: that only releases the awaiting coroutine — the worker thread kept downloading steno/PDFs and calling the LLM all the way to completion (and still wrote the cache at the end). `cancel_all` had the same hole, and the backend lifespan never cancelled the amendment pipeline at all on shutdown.

**B12 — progress off-by-one.** The amendment steno loop set `progress.done_items = i` *before* processing candidate `i`, so the admin progress bar always lagged one item behind until the loop ended.

**Latent:** per-period `_tasks` dicts were never pruned in either service; tisk single-task cancels surfaced `PeriodCancelled` as an unhandled task exception; the admin pipeline monitor recorded cooperative cancels as `error` history entries.

## Fix

New `services/cancellation.py`: `PipelineCancelled` + thread-safe `CancellationFlag` (`cancel()` / `is_cancelled()` / `check()`).

- Both services hold `_flags: dict[int, CancellationFlag]`; `cancel_period`/`cancel_all` flip flags (sync, instant); worker threads call `check()` at every stage boundary and loop top and exit promptly.
- Amendment: `cancel_check` threaded through `_run_pipeline_sync` → steno loop, PDF download loop (`merger`), summarize loop (`summarizer`), prerequisite history scrape (`identifier`). Catches `PipelineCancelled` → new `AmendmentStatus.CANCELLED`.
- Tisk: `_make_cancel_check` returns the flag's bound `check` (behavior identical, source unified); `_run_period` now catches `PipelineCancelled` itself → `PeriodStatus.CANCELLED`, no more 'exception never retrieved'.
- `cancel_all()` is sync (flips flags + pre-cancels flags created afterwards so mid-shutdown starts die immediately); new `async wait_stopped(timeout)` drains tasks, hard-cancelling stragglers past the timeout. Used by admin stop endpoint, daily refresh, and the backend lifespan — which now cancels **both** pipelines on shutdown.
- Admin `_monitor_pipeline` reads progress status post-completion to record `cancelled` history for cooperative stops (CancelledError path kept for hard cancels).
- Done-callbacks prune `_tasks`+`_flags` (identity-guarded against same-period restarts).
- B12: `done_items` incremented in a `try/finally` per candidate — correct across the loop's three `continue` paths.

Admin UI: added `AmendmentStatus.CANCELLED = 'cancelled'` (template already compares `.status.value` strings; renders the non-running branch).

## Verification

- New tests: `tests/unit/test_cancellation.py` (flag semantics, cross-thread visibility) + `tests/unit/services/test_pipeline_cancellation.py` — **amendment cancel-mid-run E2E** (worker blocked inside first steno lookup → cancel → asserts `CANCELLED` status and zero further downloads), completed-run pruning, pre-cancelled flag raises before any stage, PDF/summarize loop checkpoints, tisk cancel regressions (IN_PROGRESS/PENDING/completed/unknown, cancel_all pre-cancels new flags, wait_stopped clears state).
- Event-loop smoke test: all-periods loop with a stage blocked mid-run → cancel_all → first period completed, second cancelled at next checkpoint, clean drain, all state pruned.
- Gate: **561 passed** (was 543, +18), 26 integration deselected, coverage 59.66%, `uv run pyright` → 0 errors / 0 warnings / 0 informations, ruff clean.

## Behavior changes

- Admin pipeline stop and daily refresh now wait (bounded, ≤5s/10s + force) for pipelines to actually stop instead of fire-and-forget.
- Pipeline history records cooperative cancels as `cancelled` instead of `error`.
- Backend shutdown cancels the amendment pipeline too.