### PR TITLE
fix: bug sweep + batch writes (config-dir leak, O(n²) I/O, dead code)

### DIFF
--- a/pspcz_analyzer/routes/pages.py
+++ b/pspcz_analyzer/routes/pages.py
@@ -188,7 +188,7 @@ async def law_detail_page(request: Request, ct: int, period: int = DEFAULT_PERIO
     data_svc = request.app.state.data
     pd = data_svc.get_period(period)
     lang = getattr(request.state, "lang", "cs")
-    detail = get_law_detail(pd, ct, lang)
+    detail = get_law_detail(pd, ct, data_svc.cache_dir, lang)
     if detail is None:
         return templates.TemplateResponse(
             "laws.html",

--- a/pspcz_analyzer/routes/tisk.py
+++ b/pspcz_analyzer/routes/tisk.py
@@ -9,7 +9,6 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from pspcz_analyzer.config import (
-    DEFAULT_CACHE_DIR,
     DEFAULT_PERIOD,
     GITHUB_FEEDBACK_ENABLED,
     TISKY_PDF_DIR,
@@ -133,7 +132,7 @@ async def related_bills_api(
     if idsb <= 0:
         return HTMLResponse(f"<p>{html_mod.escape(_t('related.invalid'))}</p>")
 
-    cache_dir = DEFAULT_CACHE_DIR
+    cache_dir = request.app.state.data.cache_dir
     cached = load_related_bills_json(idsb, cache_dir)
     if cached is not None:
         bills = [asdict(b) for b in cached]

--- a/pspcz_analyzer/services/amendments/pdf_parser.py
+++ b/pspcz_analyzer/services/amendments/pdf_parser.py
@@ -16,11 +16,12 @@ from dataclasses import dataclass, field
 
 from loguru import logger
 
-# Top-level letter header: "A. Poslanec Jan Novák" or "B. Poslankyně Jana Nová"
-# Also handles "Poslanci" (plural) and "Poslankyně" (plural feminine)
+# Top-level letter header: "A. Poslanec Jan Novák" or "B. Poslankyně Jana Nová".
+# "Poslanci" covers the masculine plural; "Poslankyně" is identical in the
+# feminine singular and plural, so it covers both.
 _LETTER_HEADER_RE = re.compile(
     r"^([A-Z])\.?\s+"
-    r"(Poslanec|Poslankyně|Poslanci|Poslankyně)\s+"
+    r"(Poslanec|Poslankyně|Poslanci)\s+"
     r"(.+?)$",
     re.MULTILINE,
 )

--- a/pspcz_analyzer/services/amendments/pipeline.py
+++ b/pspcz_analyzer/services/amendments/pipeline.py
@@ -240,7 +240,7 @@ def _run_parse_stages(
                     len(candidates),
                 )
 
-            html, steno_url, failure = find_steno_for_bod(period, schuze, bod, nazev, cache_dir)
+            html, steno_url, failure = find_steno_for_bod(period, schuze, bod, cache_dir)
             if html is None:
                 if failure is not None:
                     failure_counts[failure] += 1

--- a/pspcz_analyzer/services/amendments/steno_scraper.py
+++ b/pspcz_analyzer/services/amendments/steno_scraper.py
@@ -591,7 +591,6 @@ def find_steno_for_bod(
     period: int,
     schuze: int,
     bod: int,
-    _bod_nazev: str,
     cache_dir: Path,
 ) -> tuple[str | None, str, StenoFailure | None]:
     """Find and download steno transcript pages for a specific agenda item.
@@ -606,7 +605,6 @@ def find_steno_for_bod(
         period: Electoral period number.
         schuze: Session number.
         bod: Agenda item number.
-        _bod_nazev: Title/name of the agenda item (unused, kept for API compat).
         cache_dir: Base cache directory.
 
     Returns:

--- a/pspcz_analyzer/services/amendments/summarizer.py
+++ b/pspcz_analyzer/services/amendments/summarizer.py
@@ -18,6 +18,12 @@ from pspcz_analyzer.services.amendments.cache_manager import save_amendments
 from pspcz_analyzer.services.amendments.progress import AmendmentProgress
 from pspcz_analyzer.services.llm import LLMClient, create_llm_client
 
+# How many summarized bills to accumulate before flushing the parquet +
+# notifying the UI. Saving after every single bill rewrites the whole period
+# file — O(n²) I/O — while batching by 10 keeps the admin UI's incremental
+# refresh responsive.
+_SAVE_EVERY_BILLS = 10
+
 
 def _summarize_bill_text(
     llm: LLMClient,
@@ -234,7 +240,9 @@ def _summarize_amendments(
         cache_dir: Base cache directory for intermediate saves.
         period: Electoral period number.
         progress: Progress tracker (mutated in-place).
-        on_progress: Optional callback(period, bills) for incremental UI refresh.
+        on_progress: Optional callback(period, bills) for incremental UI
+            refresh, fired after each periodic save (every
+            _SAVE_EVERY_BILLS summarized bills and once at the end).
         period_data: Loaded period data for tisk summary lookup.
         ct_to_pdf_text: Mapping of ct -> raw PDF text (transient, not cached).
         cancel_check: Optional cancellation hook raised between bills.
@@ -260,6 +268,7 @@ def _summarize_amendments(
     pdf_text_map = ct_to_pdf_text or {}
     tisk_reused = 0
     llm_generated = 0
+    summarized_since_save = 0
 
     for i, bill in enumerate(bills):
         if cancel_check:
@@ -326,11 +335,21 @@ def _summarize_amendments(
 
         progress.done_items = i + 1
 
-        # Save + notify after each bill so UI updates incrementally
+        # Save + notify periodically so the UI updates incrementally without
+        # rewriting the whole period parquet after every single bill
         if bill.bill_summary:
-            save_amendments(cache_dir, period, bills)
-            if on_progress:
-                on_progress(period, bills)
+            summarized_since_save += 1
+            if summarized_since_save >= _SAVE_EVERY_BILLS:
+                save_amendments(cache_dir, period, bills)
+                if on_progress:
+                    on_progress(period, bills)
+                summarized_since_save = 0
+
+    # Flush any summaries not yet written
+    if summarized_since_save:
+        save_amendments(cache_dir, period, bills)
+        if on_progress:
+            on_progress(period, bills)
 
     elapsed = progress.elapsed
     logger.info(

--- a/pspcz_analyzer/services/data_reader.py
+++ b/pspcz_analyzer/services/data_reader.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+from dataclasses import dataclass
 from pathlib import Path
 
 import polars as pl
@@ -56,6 +57,24 @@ from pspcz_analyzer.services.tisk import (
 )
 
 _WATCH_INTERVAL_S = 30
+
+
+@dataclass(frozen=True)
+class SharedTables:
+    """Shared cross-period tables, narrowed to non-Optional after loading.
+
+    ``_ensure_shared_loaded`` returns these so callers hold locally-typed
+    references — pyright does not narrow instance attributes across method
+    calls, which otherwise forces redundant asserts at every call site.
+    """
+
+    schuze: pl.DataFrame
+    bod_schuze: pl.DataFrame
+    tisky: pl.DataFrame
+    persons: pl.DataFrame
+    mps: pl.DataFrame
+    organs: pl.DataFrame
+    memberships: pl.DataFrame
 
 
 def _collect_parquet_mtimes(cache_dir: Path) -> dict[str, float]:
@@ -267,8 +286,13 @@ class DataReader:
             self._tisky.height,
         )
 
-    def _ensure_shared_loaded(self) -> None:
-        """Assert that shared tables have been loaded (narrows Optional types)."""
+    def _ensure_shared_loaded(self) -> SharedTables:
+        """Assert that shared tables have been loaded and return them.
+
+        Returns:
+            The shared tables as a SharedTables bundle, so callers hold
+            non-Optional references without redundant local asserts.
+        """
         assert self._schuze is not None, "Call _load_shared_tables first"
         assert self._bod_schuze is not None
         assert self._tisky is not None
@@ -276,6 +300,15 @@ class DataReader:
         assert self._mps is not None
         assert self._organs is not None
         assert self._memberships is not None
+        return SharedTables(
+            schuze=self._schuze,
+            bod_schuze=self._bod_schuze,
+            tisky=self._tisky,
+            persons=self._persons,
+            mps=self._mps,
+            organs=self._organs,
+            memberships=self._memberships,
+        )
 
     def _load_period(self, period: int) -> None:
         """Load voting data for a specific period."""
@@ -325,25 +358,20 @@ class DataReader:
             logger.info("No void votes file for period {}", period)
             void_votes = pl.DataFrame({"id_hlasovani": pl.Series([], dtype=pl.Int64)})
 
-        self._ensure_shared_loaded()
-        assert self._mps is not None
-        assert self._persons is not None
-        assert self._organs is not None
-        assert self._memberships is not None
-        assert self._schuze is not None
-        assert self._bod_schuze is not None
-        assert self._tisky is not None
+        shared = self._ensure_shared_loaded()
 
-        mp_info = build_mp_info(period, self._mps, self._persons, self._organs, self._memberships)
+        mp_info = build_mp_info(
+            period, shared.mps, shared.persons, shared.organs, shared.memberships
+        )
 
         # Pre-load topic cache for tisk lookup builder
         self._cache_mgr.load_topic_cache(period)
         tisk_lookup = build_tisk_lookup(
             period,
             votes,
-            self._schuze,
-            self._bod_schuze,
-            self._tisky,
+            shared.schuze,
+            shared.bod_schuze,
+            shared.tisky,
             self.tisk_text,
             self._cache_mgr.topic_cache,
             self._cache_mgr.summary_cache,

--- a/pspcz_analyzer/services/law_service.py
+++ b/pspcz_analyzer/services/law_service.py
@@ -1,22 +1,26 @@
 """Service functions for the laws/bills (zákony) page."""
 
-from pspcz_analyzer.config import DEFAULT_CACHE_DIR, TISKY_PDF_DIR
+from pathlib import Path
+
+from pspcz_analyzer.config import TISKY_PDF_DIR
 from pspcz_analyzer.models.amendment_models import BillAmendmentData
 from pspcz_analyzer.models.tisk_models import PeriodData, TiskInfo
 from pspcz_analyzer.services.affiliation import amendment_driver
 
 
-def _tisk_pdf_exists(period: int, ct: int) -> bool:
+def _tisk_pdf_exists(cache_dir: Path, period: int, ct: int) -> bool:
     """Check whether a cached bill PDF exists for this tisk.
 
     Args:
+        cache_dir: Base cache directory (the configured one, so the
+            Docker bind-mount layout is respected).
         period: Electoral period number.
         ct: Tisk number.
 
     Returns:
         True if {cache}/tisky_pdf/{period}/{ct}.pdf is present.
     """
-    return (DEFAULT_CACHE_DIR / TISKY_PDF_DIR / str(period) / f"{ct}.pdf").exists()
+    return (cache_dir / TISKY_PDF_DIR / str(period) / f"{ct}.pdf").exists()
 
 
 def _bill_driver(bill: BillAmendmentData, coalition: frozenset[str]) -> str:
@@ -272,6 +276,7 @@ def _find_votes_for_ct(data: PeriodData, ct: int) -> list[dict]:
 def law_detail(
     data: PeriodData,
     ct: int,
+    cache_dir: Path,
     lang: str = "cs",
 ) -> dict | None:
     """Get full detail for a single bill by tisk number.
@@ -279,6 +284,7 @@ def law_detail(
     Args:
         data: Period data.
         ct: Tisk number (cislo tisku).
+        cache_dir: Base cache directory for PDF existence checks.
         lang: Language code for summaries/topics.
 
     Returns:
@@ -332,7 +338,7 @@ def law_detail(
         "submitter": submitter,
         "law_number": law_number,
         "history": history,
-        "has_pdf": _tisk_pdf_exists(tisk.period, ct),
+        "has_pdf": _tisk_pdf_exists(cache_dir, tisk.period, ct),
         "pdf_url": f"/api/tisk-pdf/{tisk.period}/{ct}",
         "amendment_entries": amendment_entries,
         "has_amendments": len(amendment_entries) > 0,

--- a/pspcz_analyzer/services/llm/client.py
+++ b/pspcz_analyzer/services/llm/client.py
@@ -927,7 +927,7 @@ class LLMClient:
 
         amendments_with_text = sum(1 for a in amendments if a.get("amendment_text"))
         logger.debug(
-            "%s summarize_amendments(%s): %d/%d amendments have per-amendment text",
+            "{} summarize_amendments({}): {}/{} amendments have per-amendment text",
             self._log_prefix,
             lang,
             amendments_with_text,

--- a/pspcz_analyzer/services/tisk/classifier.py
+++ b/pspcz_analyzer/services/tisk/classifier.py
@@ -15,6 +15,12 @@ from pspcz_analyzer.services.llm import (
     serialize_topics,
 )
 
+# How many newly classified tisky to accumulate before flushing the parquet.
+# Writing after every single tisk rewrites the whole period file — O(n²) I/O
+# that turns re-classification of a large cache into hours. Batching keeps
+# crash-resume cheap (at most this many classifications are redone).
+_SAVE_EVERY_TISKS = 25
+
 
 def classify_and_save(
     period: int,
@@ -27,9 +33,9 @@ def classify_and_save(
     """Run topic classification on extracted texts, save parquet, return maps.
 
     Uses LLM when available (free-form topics), falls back to keyword matching.
-    Saves incrementally after each tisk and resumes from where it left off.
-    Smart caching: tisks with topics but no summary are re-processed for
-    summaries only (2 LLM calls instead of 4).
+    Saves periodically (every _SAVE_EVERY_TISKS new records, plus once at the
+    end) and resumes from where it left off. Smart caching: tisks with topics
+    but no summary are re-processed for summaries only (2 LLM calls instead of 4).
 
     Args:
         force_cts: Tisk numbers to fully re-classify + re-summarize even if
@@ -96,6 +102,7 @@ def classify_and_save(
         # Without LLM, return whatever we have cached
         return _build_topic_summary_maps(records, period)
 
+    new_since_save = 0
     for i, (ct, text_path) in enumerate(sorted(remaining.items()), fully_done + 1):
         if cancel_check:
             cancel_check()
@@ -110,13 +117,20 @@ def classify_and_save(
             cancel_check=cancel_check,
         )
         records.append(record)
+        new_since_save += 1
 
-        # Save after every tisk so progress is never lost
-        # (atomic — the frontend may read this parquet at any moment)
-        write_parquet_atomic(pl.DataFrame(records), parquet_path)
+        # Periodic atomic save (the frontend may read this parquet at any
+        # moment) so a crash redoes at most _SAVE_EVERY_TISKS classifications
+        if new_since_save >= _SAVE_EVERY_TISKS:
+            write_parquet_atomic(pl.DataFrame(records), parquet_path)
+            new_since_save = 0
 
         if progress_callback is not None:
             progress_callback(i, total)
+
+    # Flush any records not yet written
+    if new_since_save:
+        write_parquet_atomic(pl.DataFrame(records), parquet_path)
 
     # Build return maps from all records (existing + new)
     return _build_topic_summary_maps(records, period)
@@ -325,27 +339,20 @@ def _build_topic_summary_maps(
 ) -> tuple[dict[int, list[str]], dict[int, str], dict[int, str]]:
     """Build topic, summary, and summary_en maps from classification records.
 
-    Also populates the topic_en_map on the module-level _topic_en_maps dict
-    so it can be retrieved by the cache manager.
+    English topics are not returned here — consumers read the ``topic_en``
+    parquet column through TiskCacheManager.topic_en_cache instead.
     """
     topic_map: dict[int, list[str]] = {}
-    topic_en_map: dict[int, list[str]] = {}
     summary_map: dict[int, str] = {}
     summary_en_map: dict[int, str] = {}
     for r in records:
         parsed = deserialize_topics(r.get("topic", ""))
         if parsed:
             topic_map[r["ct"]] = parsed
-        parsed_en = deserialize_topics(r.get("topic_en", ""))
-        if parsed_en:
-            topic_en_map[r["ct"]] = parsed_en
         if r.get("summary"):
             summary_map[r["ct"]] = r["summary"]
         if r.get("summary_en"):
             summary_en_map[r["ct"]] = r["summary_en"]
-
-    # Store English topic map for retrieval by cache manager
-    _topic_en_maps[period] = topic_en_map
 
     if log:
         classified = len(topic_map)
@@ -360,12 +367,3 @@ def _build_topic_summary_maps(
         )
 
     return topic_map, summary_map, summary_en_map
-
-
-# Module-level store for English topic maps (populated by _build_topic_summary_maps)
-_topic_en_maps: dict[int, dict[int, list[str]]] = {}
-
-
-def get_topic_en_map(period: int) -> dict[int, list[str]]:
-    """Get the English topic map for a period (populated during classify_and_save)."""
-    return _topic_en_maps.get(period, {})

--- a/pspcz_analyzer/services/tisk/io/extractor.py
+++ b/pspcz_analyzer/services/tisk/io/extractor.py
@@ -74,15 +74,18 @@ def extract_text_from_pdf(pdf_path: Path) -> str:
     When PyMuPDF fails or returns empty text (common for HTML files saved
     as .pdf by psp.cz), falls back to BeautifulSoup HTML parsing.
     """
+    doc = None
     try:
         doc = pymupdf.open(pdf_path)
         pages = [str(page.get_text()) for page in doc]
-        doc.close()
         text = "\n\n".join(pages)
         if text.strip():
             return text
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("PyMuPDF could not extract from {} ({}), trying fallback", pdf_path.name, exc)
+    finally:
+        if doc is not None:
+            doc.close()
 
     # Fallback: check if file is actually HTML
     html_text = _extract_text_from_html(pdf_path)

--- a/tests/unit/services/test_amendment_summarizer.py
+++ b/tests/unit/services/test_amendment_summarizer.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pspcz_analyzer.models.amendment_models import AmendmentVote
-from pspcz_analyzer.services.amendments.summarizer import _build_amendment_meta
+import pymupdf
+
+from pspcz_analyzer.models.amendment_models import AmendmentVote, BillAmendmentData
+from pspcz_analyzer.services.amendments import summarizer
+from pspcz_analyzer.services.amendments.progress import AmendmentProgress
+from pspcz_analyzer.services.amendments.summarizer import (
+    _build_amendment_meta,
+    _summarize_amendments,
+)
 from pspcz_analyzer.services.llm.parsers import (
     _format_amendments_list,
     _normalize_amendment_letter,
@@ -231,3 +238,108 @@ class TestExtractTextFromPdfHtmlFallback:
         result = extract_text_from_pdf(pdf_path)
         # Should extract something (even with encoding fallback)
         assert "republika" in result
+
+    def test_closes_doc_even_when_extraction_raises(self, tmp_path: Path, monkeypatch) -> None:
+        """The PyMuPDF document must be closed when page iteration raises."""
+        closed: list[bool] = []
+
+        class _FakeDoc:
+            def __iter__(self):
+                raise RuntimeError("malformed PDF")
+
+            def close(self) -> None:
+                closed.append(True)
+
+        monkeypatch.setattr(pymupdf, "open", lambda _path: _FakeDoc())
+        pdf_path = tmp_path / "bad.pdf"
+        pdf_path.write_bytes(b"not pdf, not html")
+        assert extract_text_from_pdf(pdf_path) == ""
+        assert closed == [True]
+
+
+class TestSummarizeAmendmentsBatching:
+    """_summarize_amendments must flush parquet periodically, not per bill."""
+
+    @staticmethod
+    def _make_bills(n: int) -> list[BillAmendmentData]:
+        return [
+            BillAmendmentData(
+                period=10,
+                schuze=1,
+                bod=i,
+                ct=100 + i,
+                tisk_nazev=f"tisk {i}",
+                amendments=[AmendmentVote(letter="A", vote_number=1, amendment_text="text A")],
+            )
+            for i in range(n)
+        ]
+
+    @staticmethod
+    def _patch_summarizer(monkeypatch, summary: str = "sum") -> list[int]:
+        """Fake the LLM client, per-bill summaries, and save_amendments.
+
+        Returns:
+            List that records len(bills) for every save_amendments call.
+        """
+
+        class _FakeLLM:
+            provider = "fake"
+            model = "fake-model"
+
+            def is_available(self) -> bool:
+                return True
+
+        saves: list[int] = []
+        monkeypatch.setattr(summarizer, "create_llm_client", lambda: _FakeLLM())
+        monkeypatch.setattr(
+            summarizer,
+            "_summarize_bill_text",
+            lambda llm, text, title, bill_index, total_bills: (summary, summary),
+        )
+        monkeypatch.setattr(
+            summarizer,
+            "_summarize_per_amendment",
+            lambda llm, bill, bill_index, total_bills, bill_context="", pdf_text="": 1,
+        )
+        monkeypatch.setattr(
+            summarizer,
+            "save_amendments",
+            lambda cache_dir, period, bills: saves.append(len(bills)),
+        )
+        return saves
+
+    def test_saves_every_10_bills_plus_final(self, tmp_path: Path, monkeypatch) -> None:
+        saves = self._patch_summarizer(monkeypatch)
+        notified: list[int] = []
+        bills = self._make_bills(12)
+        progress = AmendmentProgress()
+
+        _summarize_amendments(
+            bills,
+            tmp_path,
+            10,
+            progress,
+            on_progress=lambda p, b: notified.append(len(b)),
+        )
+
+        # 12 summarized bills -> one flush at 10 + one final flush (not 12 saves)
+        assert len(saves) == 2
+        assert saves == [12, 12]
+        assert notified == [12, 12]
+        assert progress.done_items == 12
+
+    def test_single_final_flush_under_threshold(self, tmp_path: Path, monkeypatch) -> None:
+        saves = self._patch_summarizer(monkeypatch)
+        bills = self._make_bills(5)
+
+        _summarize_amendments(bills, tmp_path, 10, AmendmentProgress())
+
+        assert saves == [5]
+
+    def test_no_saves_when_no_summaries(self, tmp_path: Path, monkeypatch) -> None:
+        saves = self._patch_summarizer(monkeypatch, summary="")
+        bills = self._make_bills(5)
+
+        _summarize_amendments(bills, tmp_path, 10, AmendmentProgress())
+
+        assert saves == []

--- a/tests/unit/services/test_classifier.py
+++ b/tests/unit/services/test_classifier.py
@@ -1,0 +1,84 @@
+"""Tests for the tisk topic classifier save batching."""
+
+from pathlib import Path
+
+from pspcz_analyzer.services.tisk import classifier
+from pspcz_analyzer.services.tisk.classifier import classify_and_save
+
+
+class _FakeLLM:
+    """Minimal LLM client stand-in: always available, never called."""
+
+    model = "fake-model"
+
+    def is_available(self) -> bool:
+        return True
+
+
+def _patch_classifier(monkeypatch) -> list[int]:
+    """Fake the LLM client, per-tisk classification, and parquet writes.
+
+    Returns:
+        List that records the DataFrame height for every atomic write.
+    """
+    writes: list[int] = []
+    monkeypatch.setattr(classifier, "create_llm_client", lambda: _FakeLLM())
+    monkeypatch.setattr(
+        classifier, "write_parquet_atomic", lambda df, path: writes.append(df.height)
+    )
+    monkeypatch.setattr(
+        classifier,
+        "_classify_single_tisk",
+        lambda ct, text_path, llm, use_ai, i, total, existing_record=None, cancel_check=None: {
+            "ct": ct,
+            "topic": '["téma"]',
+            "topic_en": '["topic"]',
+            "summary": "souhrn",
+            "summary_en": "summary",
+            "source": "llm:fake-model",
+        },
+    )
+    return writes
+
+
+class TestClassifyAndSaveBatching:
+    """classify_and_save must flush parquet periodically, not per tisk."""
+
+    def test_saves_every_25_plus_final(self, tmp_path: Path, monkeypatch) -> None:
+        writes = _patch_classifier(monkeypatch)
+        text_paths = {ct: tmp_path / f"{ct}.txt" for ct in range(1, 31)}
+
+        topic_map, summary_map, summary_en_map = classify_and_save(9, text_paths, tmp_path)
+
+        # 30 tisks: one write at 25, one final flush at 30 — not 30 writes
+        assert writes == [25, 30]
+        assert len(topic_map) == 30
+        assert topic_map[1] == ["téma"]
+        assert len(summary_map) == 30
+        assert len(summary_en_map) == 30
+
+    def test_single_final_flush_under_threshold(self, tmp_path: Path, monkeypatch) -> None:
+        writes = _patch_classifier(monkeypatch)
+        text_paths = {ct: tmp_path / f"{ct}.txt" for ct in range(1, 8)}
+
+        classify_and_save(9, text_paths, tmp_path)
+
+        assert writes == [7]
+
+    def test_no_writes_when_nothing_to_process(self, tmp_path: Path, monkeypatch) -> None:
+        writes = _patch_classifier(monkeypatch)
+
+        classify_and_save(9, {}, tmp_path)
+
+        assert writes == []
+
+    def test_progress_callback_fires_per_item(self, tmp_path: Path, monkeypatch) -> None:
+        _patch_classifier(monkeypatch)
+        text_paths = {ct: tmp_path / f"{ct}.txt" for ct in range(1, 4)}
+        callbacks: list[tuple[int, int]] = []
+
+        classify_and_save(
+            9, text_paths, tmp_path, progress_callback=lambda i, t: callbacks.append((i, t))
+        )
+
+        assert callbacks == [(1, 3), (2, 3), (3, 3)]

--- a/tests/unit/services/test_law_service.py
+++ b/tests/unit/services/test_law_service.py
@@ -1,5 +1,7 @@
 """Tests for the law listing and detail service."""
 
+from pathlib import Path
+
 from pspcz_analyzer.models.amendment_models import AmendmentVote, BillAmendmentData
 from pspcz_analyzer.models.tisk_models import PeriodData, TiskInfo
 from pspcz_analyzer.services.law_service import (
@@ -14,6 +16,9 @@ from tests.fixtures.sample_data import (
     make_void_votes,
     make_votes,
 )
+
+# Cache dir that never exists — law_detail only checks PDF presence there.
+_NO_CACHE_DIR = Path(__file__).parent / "no-such-cache-dir"
 
 
 def _make_tisk(
@@ -270,18 +275,18 @@ class TestGetAllStatusLabels:
 class TestLawDetail:
     def test_returns_dict_for_existing_ct(self):
         data = _make_data_with_laws()
-        result = law_detail(data, ct=200)
+        result = law_detail(data, ct=200, cache_dir=_NO_CACHE_DIR)
         assert isinstance(result, dict)
         assert result["ct"] == 200
 
     def test_not_found_returns_none(self):
         data = _make_data_with_laws()
-        result = law_detail(data, ct=999)
+        result = law_detail(data, ct=999, cache_dir=_NO_CACHE_DIR)
         assert result is None
 
     def test_contains_bill_info(self):
         data = _make_data_with_laws()
-        result = law_detail(data, ct=200)
+        result = law_detail(data, ct=200, cache_dir=_NO_CACHE_DIR)
         assert result is not None
         assert result["nazev"] == "Zákon o daních"
         assert result["status"] == "vyhlášeno"
@@ -289,19 +294,19 @@ class TestLawDetail:
 
     def test_contains_summary(self):
         data = _make_data_with_laws()
-        result = law_detail(data, ct=200)
+        result = law_detail(data, ct=200, cache_dir=_NO_CACHE_DIR)
         assert result is not None
         assert result["summary"] == "Shrnutí zákona."
 
     def test_english_summary(self):
         data = _make_data_with_laws()
-        result = law_detail(data, ct=200, lang="en")
+        result = law_detail(data, ct=200, cache_dir=_NO_CACHE_DIR, lang="en")
         assert result is not None
         assert result["summary"] == "Bill summary."
 
     def test_contains_amendment_entries(self):
         data = _make_data_with_laws()
-        result = law_detail(data, ct=200)
+        result = law_detail(data, ct=200, cache_dir=_NO_CACHE_DIR)
         assert result is not None
         assert result["has_amendments"] is True
         assert len(result["amendment_entries"]) == 1
@@ -309,13 +314,13 @@ class TestLawDetail:
 
     def test_no_amendments_for_bill(self):
         data = _make_data_with_laws()
-        result = law_detail(data, ct=300)
+        result = law_detail(data, ct=300, cache_dir=_NO_CACHE_DIR)
         assert result is not None
         assert result["has_amendments"] is False
         assert len(result["amendment_entries"]) == 0
 
     def test_contains_topics(self):
         data = _make_data_with_laws()
-        result = law_detail(data, ct=200)
+        result = law_detail(data, ct=200, cache_dir=_NO_CACHE_DIR)
         assert result is not None
         assert "Ekonomika" in result["topics"]

--- a/tests/unit/services/test_pipeline_cancellation.py
+++ b/tests/unit/services/test_pipeline_cancellation.py
@@ -39,7 +39,7 @@ def _make_blocking_find_steno(
     """Fake find_steno_for_bod: blocks on the first call until released."""
 
     def fake_find_steno(
-        period: int, schuze: int, bod: int, nazev: str, cache_dir: Path
+        period: int, schuze: int, bod: int, cache_dir: Path
     ) -> tuple[None, None, None]:
         calls.append((schuze, bod))
         if len(calls) == 1:

--- a/tests/unit/services/test_steno_scraper.py
+++ b/tests/unit/services/test_steno_scraper.py
@@ -99,7 +99,7 @@ class TestCollectBodSubpages:
 class TestFindStenoForBod:
     def test_concatenates_all_subpages(self, monkeypatch):
         _patch_downloads(monkeypatch, day_pages={"17-1.html": DAY1_HTML, "17-3.html": DAY3_HTML})
-        html, first_url, failure = find_steno_for_bod(10, 17, 2, "", Path("/tmp"))
+        html, first_url, failure = find_steno_for_bod(10, 17, 2, Path("/tmp"))
         assert failure is None
         assert html is not None
         assert first_url.endswith("s100.htm")
@@ -108,14 +108,14 @@ class TestFindStenoForBod:
 
     def test_bod_not_in_index(self, monkeypatch):
         _patch_downloads(monkeypatch, day_pages={"17-1.html": DAY1_HTML, "17-3.html": DAY3_HTML})
-        html, _url, failure = find_steno_for_bod(10, 17, 9, "", Path("/tmp"))
+        html, _url, failure = find_steno_for_bod(10, 17, 9, Path("/tmp"))
         assert html is None
         assert failure is StenoFailure.BOD_NOT_IN_INDEX
 
     def test_keeps_last_n_when_over_cap(self, monkeypatch):
         _patch_downloads(monkeypatch, day_pages={"17-1.html": DAY1_HTML, "17-3.html": DAY3_HTML})
         monkeypatch.setattr(steno_scraper, "STENO_MAX_SUBPAGES_PER_BOD", 2)
-        html, first_url, failure = find_steno_for_bod(10, 17, 2, "", Path("/tmp"))
+        html, first_url, failure = find_steno_for_bod(10, 17, 2, Path("/tmp"))
         assert failure is None
         assert html is not None
         # Voting is at the end -> keep the last 2 (s300, s301), drop s100/s101.


### PR DESCRIPTION
Part of the repo professionalization plan (PR7 — low-severity bug sweep + R2 perf).

## Config-dir leak (Docker bind-mount breakage)

Two spots used the compile-time `DEFAULT_CACHE_DIR` instead of the configured cache dir, so with `PSPCZ_CACHE_DIR`/the Docker bind mount they read/wrote the wrong tree:

- `routes/tisk.py::related_bills_api` → now `request.app.state.data.cache_dir`
- `law_service._tisk_pdf_exists` → explicit `cache_dir: Path` param threaded through `law_detail()` from `pages.py`

## Resource leak

`extractor.extract_text_from_pdf`: the `pymupdf` document was only closed on the happy path — any raise during page iteration leaked the handle. Now `try/finally` + a debug log (the old handler was a bare `except: pass`).

## R2 perf — O(n²) parquet I/O

Both writers rewrote the **full-period parquet after every single item**:

- `classifier.classify_and_save` → flush every 25 new records + once at the end
- `summarizer._summarize_amendments` → flush every 10 summarized bills + final; `on_progress` fires with each save (it reloads in-memory data from disk, so it must track saves, not bills)

Crash-resume semantics preserved (classifier still recomputes `remaining` from the parquet on start). On re-classification of a large cache this is minutes instead of hours. Composes with the atomic writes from #63.

## Dead code / cleanup

- `classifier._topic_en_maps` + `get_topic_en_map` — verified zero callers; every consumer reads the `topic_en` parquet column via `TiskCacheManager.topic_en_cache`
- `steno_scraper.find_steno_for_bod` unused `_bod_nazev` param (all 3 call sites updated)
- `pdf_parser._LETTER_HEADER_RE` duplicated `Poslankyně` alternation token (feminine singular/plural are identical in Czech)
- `data_reader._load_period`: 7 redundant asserts collapsed — `_ensure_shared_loaded()` now returns a frozen `SharedTables` dataclass (pyright can't narrow instance attributes across method calls, which is why the asserts existed)
- `llm/client.py`: the only remaining printf-style (`%s`) loguru format → `{}`

**Note:** the audit's "feedback `suffix=""`" item was dropped — zero matches in `feedback_service.py` (already fixed or misattributed).

## Tests

+8 new: classifier batching ×4, summarizer batching ×3 (10+final, under-threshold, no-summary-no-save), extractor doc-close-on-raise ×1. Steno/law/cancellation tests updated for the signature changes.

**Gate:** 569 passed / 26 integration deselected, coverage 61.00% (was 59.66%), pyright 0/0/0, ruff clean.