### PR TITLE
refactor: shared domain helpers — vote labels, party majority, search folding, LLM retry

### DIFF
--- a/pspcz_analyzer/services/amendment_service.py
+++ b/pspcz_analyzer/services/amendment_service.py
@@ -9,6 +9,8 @@ import polars as pl
 from pspcz_analyzer.models.amendment_models import AmendmentVote, BillAmendmentData
 from pspcz_analyzer.models.tisk_models import PeriodData
 from pspcz_analyzer.services.affiliation import amendment_driver
+from pspcz_analyzer.services.labels import mp_vote_label
+from pspcz_analyzer.utils.text import normalize_czech
 
 
 def _amendment_to_dict(amend: AmendmentVote, coalition: frozenset[str]) -> dict:
@@ -104,10 +106,10 @@ def list_amendment_bills(
     """
     bills = list(data.amendment_data.values())
 
-    # Filter by search text
+    # Filter by search text (diacritics-insensitive, like the votes search)
     if search:
-        search_lower = search.lower()
-        bills = [b for b in bills if search_lower in b.tisk_nazev.lower()]
+        q = normalize_czech(search.strip())
+        bills = [b for b in bills if q in normalize_czech(b.tisk_nazev)]
 
     # Sort by schuze desc, then bod desc
     bills.sort(key=lambda b: (b.schuze, b.bod), reverse=True)
@@ -259,32 +261,6 @@ def amendment_detail(
     }
 
 
-def _vote_label(code: str) -> str:
-    """Map psp.cz vote result code to display label.
-
-    Args:
-        code: Single-character vote code (A, B, C, F, @, M).
-
-    Returns:
-        Human-readable label.
-    """
-    match code:
-        case "A":
-            return "YES"
-        case "B":
-            return "NO"
-        case "C":
-            return "ABSTAINED"
-        case "F":
-            return "DID_NOT_VOTE"
-        case "@":
-            return "Absent"
-        case "M":
-            return "Excused"
-        case _:
-            return "Unknown"
-
-
 def amendment_mp_votes(
     data: PeriodData,
     id_hlasovani: int,
@@ -335,7 +311,7 @@ def amendment_mp_votes(
                 "prijmeni": row.get("prijmeni", ""),
                 "party": row.get("party", ""),
                 "vote_code": row.get("vysledek", ""),
-                "vote_label": _vote_label(row.get("vysledek", "")),
+                "vote_label": mp_vote_label(row.get("vysledek", "")),
             }
         )
 

--- a/pspcz_analyzer/services/amendments/coalition_service.py
+++ b/pspcz_analyzer/services/amendments/coalition_service.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from pspcz_analyzer.models.enums import VoteResult
 from pspcz_analyzer.models.tisk_models import PeriodData
+from pspcz_analyzer.services.party_voting import party_majority_direction
 
 
 def _compute_party_agreement_on_amendments(
@@ -49,22 +50,7 @@ def _compute_party_agreement_on_amendments(
     )
 
     # Compute party majority direction per vote
-    party_majority = (
-        active.group_by(["id_hlasovani", "party"])
-        .agg(
-            (pl.col("vysledek") == VoteResult.YES).sum().alias("yes_count"),
-            (pl.col("vysledek") == VoteResult.NO).sum().alias("no_count"),
-        )
-        .with_columns(
-            pl.when(pl.col("yes_count") > pl.col("no_count"))
-            .then(pl.lit("YES"))
-            .when(pl.col("no_count") > pl.col("yes_count"))
-            .then(pl.lit("NO"))
-            .otherwise(pl.lit(None))
-            .alias("direction")
-        )
-        .filter(pl.col("direction").is_not_null())
-    )
+    party_majority = party_majority_direction(active, direction_alias="direction")
 
     # Self-join to get party pairs per vote
     pairs = party_majority.join(

--- a/pspcz_analyzer/services/labels.py
+++ b/pspcz_analyzer/services/labels.py
@@ -1,0 +1,57 @@
+"""Display tokens for vote codes and vote outcomes.
+
+These tokens are *machine-facing*: Jinja2 templates compare them to
+select CSS classes and then render their own localized strings via
+gettext (see vote_detail.html, law_detail.html, loyalty_table.html).
+They must never be localized here — templates would silently fall
+through to their else branches.
+"""
+
+from pspcz_analyzer.models.enums import VoteResult
+
+# Per-MP vote code -> display token. vote_detail.html compares
+# YES/NO/ABSTAINED/Absent/Excused; any other value (incl. DID_NOT_VOTE)
+# renders in the neutral branch.
+_MP_VOTE_LABELS: dict[str, str] = {
+    VoteResult.YES: "YES",
+    VoteResult.NO: "NO",
+    VoteResult.ABSTAINED: "ABSTAINED",
+    VoteResult.DID_NOT_VOTE: "DID_NOT_VOTE",
+    VoteResult.ABSENT: "Absent",
+    VoteResult.EXCUSED: "Excused",
+}
+
+# Aggregate vote outcome code (hl_hlasovani.vysledek) -> display token.
+# law_detail.html compares passed/rejected/void.
+_VOTE_OUTCOME_LABELS: dict[str, str] = {
+    "A": "passed",
+    "R": "rejected",
+    "Z": "void",
+}
+
+
+def mp_vote_label(code: str) -> str:
+    """Map a psp.cz per-MP vote code (A/B/C/F/@/M) to a display token.
+
+    Args:
+        code: Single-character vote result code (may be empty).
+
+    Returns:
+        The display token; the raw code for unknown non-empty codes,
+        "?" for an empty code.
+    """
+    if label := _MP_VOTE_LABELS.get(code):
+        return label
+    return code or "?"
+
+
+def vote_outcome_label(vysledek: str) -> str:
+    """Map an aggregate vote outcome code (A/R/Z) to a display token.
+
+    Args:
+        vysledek: Vote outcome code from the votes table.
+
+    Returns:
+        "passed" / "rejected" / "void", or the raw code when unknown.
+    """
+    return _VOTE_OUTCOME_LABELS.get(vysledek, vysledek)

--- a/pspcz_analyzer/services/law_service.py
+++ b/pspcz_analyzer/services/law_service.py
@@ -6,6 +6,8 @@ from pspcz_analyzer.config import TISKY_PDF_DIR
 from pspcz_analyzer.models.amendment_models import BillAmendmentData
 from pspcz_analyzer.models.tisk_models import PeriodData, TiskInfo
 from pspcz_analyzer.services.affiliation import amendment_driver
+from pspcz_analyzer.services.labels import vote_outcome_label
+from pspcz_analyzer.utils.text import normalize_czech
 
 
 def _tisk_pdf_exists(cache_dir: Path, period: int, ct: int) -> bool:
@@ -186,10 +188,10 @@ def list_laws(
     """
     tisky = _deduplicate_tisky(data)
 
-    # Filter by search text
+    # Filter by search text (diacritics-insensitive, like the votes search)
     if search:
-        search_lower = search.lower()
-        tisky = [t for t in tisky if search_lower in t.nazev.lower()]
+        q = normalize_czech(search.strip())
+        tisky = [t for t in tisky if q in normalize_czech(t.nazev)]
 
     # Filter by status (exact match)
     if status_filter and status_filter != "all":
@@ -247,16 +249,7 @@ def _find_votes_for_ct(data: PeriodData, ct: int) -> list[dict]:
     for _, row in enumerate(data.votes.iter_rows(named=True)):
         key = (row.get("schuze"), row.get("bod"))
         if key in schuze_bod_pairs:
-            vysledek = row.get("vysledek", "")
-            match vysledek:
-                case "A":
-                    result_label = "passed"
-                case "R":
-                    result_label = "rejected"
-                case "Z":
-                    result_label = "void"
-                case _:
-                    result_label = vysledek
+            result_label = vote_outcome_label(row.get("vysledek", ""))
             votes_list.append(
                 {
                     "id_hlasovani": row.get("id_hlasovani"),

--- a/pspcz_analyzer/services/llm/client.py
+++ b/pspcz_analyzer/services/llm/client.py
@@ -578,7 +578,11 @@ class LLMClient:
             return _parse_consolidation_json(data, all_topics)
 
         prompt = _CONSOLIDATION_PROMPT_TEMPLATE.format(n=len(all_topics), topics_list=topics_list)
-        response = self._generate(prompt, _CONSOLIDATION_SYSTEM)
+        response = self._generate_with_retry(
+            prompt,
+            _CONSOLIDATION_SYSTEM,
+            validator=lambda r: bool(r.strip()),
+        )
         if not response:
             return {t: t for t in all_topics}
         return self._parse_consolidation_response(response, all_topics)
@@ -642,7 +646,11 @@ class LLMClient:
         prompt = _CONSOLIDATION_PROMPT_TEMPLATE_EN.format(
             n=len(all_topics), topics_list=topics_list
         )
-        response = self._generate(prompt, _CONSOLIDATION_SYSTEM_EN)
+        response = self._generate_with_retry(
+            prompt,
+            _CONSOLIDATION_SYSTEM_EN,
+            validator=lambda r: bool(r.strip()),
+        )
         if not response:
             return {t: t for t in all_topics}
         return self._parse_consolidation_response(response, all_topics)
@@ -889,7 +897,11 @@ class LLMClient:
             en = _render_comparison_markdown_en(data) if data else ""
         else:
             prompt = _COMPARISON_PROMPT_TEMPLATE_EN.format(**fmt_kwargs)
-            response = self._generate(prompt, _COMPARISON_SYSTEM_EN)
+            response = self._generate_with_retry(
+                prompt,
+                _COMPARISON_SYSTEM_EN,
+                validator=lambda r: bool(r.strip()),
+            )
             en = self._strip_think(response) if response else ""
 
         return {"cs": cs, "en": en}

--- a/pspcz_analyzer/services/loyalty_service.py
+++ b/pspcz_analyzer/services/loyalty_service.py
@@ -4,6 +4,7 @@ import polars as pl
 
 from pspcz_analyzer.models.enums import VoteResult
 from pspcz_analyzer.models.tisk_models import PeriodData
+from pspcz_analyzer.services.party_voting import party_majority_direction
 
 
 def compute_loyalty(
@@ -34,22 +35,7 @@ def compute_loyalty(
     )
 
     # For each vote + party, compute majority direction
-    party_majority = (
-        active_votes.group_by(["id_hlasovani", "party"])
-        .agg(
-            (pl.col("vysledek") == VoteResult.YES).sum().alias("yes_count"),
-            (pl.col("vysledek") == VoteResult.NO).sum().alias("no_count"),
-        )
-        .with_columns(
-            pl.when(pl.col("yes_count") > pl.col("no_count"))
-            .then(pl.lit(VoteResult.YES))
-            .when(pl.col("no_count") > pl.col("yes_count"))
-            .then(pl.lit(VoteResult.NO))
-            .otherwise(pl.lit(None))
-            .alias("party_direction")
-        )
-        .filter(pl.col("party_direction").is_not_null())
-    )
+    party_majority = party_majority_direction(active_votes)
 
     # Join back to individual votes
     with_direction = active_votes.join(

--- a/pspcz_analyzer/services/party_voting.py
+++ b/pspcz_analyzer/services/party_voting.py
@@ -1,0 +1,50 @@
+"""Shared polars helpers for party-level voting analysis."""
+
+from collections.abc import Sequence
+
+import polars as pl
+
+from pspcz_analyzer.models.enums import VoteResult
+
+_DEFAULT_GROUP_KEYS: tuple[str, str] = ("id_hlasovani", "party")
+
+
+def party_majority_direction(
+    votes: pl.DataFrame,
+    group_keys: Sequence[str] = _DEFAULT_GROUP_KEYS,
+    direction_alias: str = "party_direction",
+) -> pl.DataFrame:
+    """Compute each group's majority direction (YES vs NO).
+
+    A group's direction is YES when its YES votes outnumber its NO votes
+    and vice versa; exact ties carry no direction and are dropped.
+    Shared by loyalty (rebellion detection) and the amendment coalition
+    analysis so the two can never drift apart.
+
+    Args:
+        votes: Frame with a "vysledek" column holding VoteResult values
+            plus one column per group key.
+        group_keys: Columns identifying a group (default vote + party).
+        direction_alias: Name of the resulting direction column; its
+            values are VoteResult.YES / VoteResult.NO.
+
+    Returns:
+        Grouped frame with yes_count, no_count, and the direction
+        column; tied (direction-less) groups are filtered out.
+    """
+    return (
+        votes.group_by(list(group_keys))
+        .agg(
+            (pl.col("vysledek") == VoteResult.YES).sum().alias("yes_count"),
+            (pl.col("vysledek") == VoteResult.NO).sum().alias("no_count"),
+        )
+        .with_columns(
+            pl.when(pl.col("yes_count") > pl.col("no_count"))
+            .then(pl.lit(VoteResult.YES))
+            .when(pl.col("no_count") > pl.col("yes_count"))
+            .then(pl.lit(VoteResult.NO))
+            .otherwise(pl.lit(None))
+            .alias(direction_alias)
+        )
+        .filter(pl.col(direction_alias).is_not_null())
+    )

--- a/pspcz_analyzer/services/votes_service.py
+++ b/pspcz_analyzer/services/votes_service.py
@@ -9,6 +9,7 @@ import polars as pl
 from pspcz_analyzer.i18n import gettext as _
 from pspcz_analyzer.models.enums import VoteResult
 from pspcz_analyzer.models.tisk_models import PeriodData
+from pspcz_analyzer.services.labels import mp_vote_label
 from pspcz_analyzer.utils.text import normalize_czech
 
 # Keys into i18n translations, resolved at call time
@@ -282,21 +283,12 @@ def _build_party_breakdown(mp_detail: pl.DataFrame) -> list[dict]:
 
 def _build_mp_breakdown(mp_detail: pl.DataFrame) -> list[dict]:
     """Build per-MP vote list with human-readable labels."""
-    vote_labels = {
-        VoteResult.YES: "YES",
-        VoteResult.NO: "NO",
-        VoteResult.ABSTAINED: "ABSTAINED",
-        VoteResult.DID_NOT_VOTE: "Passive",
-        VoteResult.ABSENT: "Absent",
-        VoteResult.EXCUSED: "Excused",
-    }
-
     mp_list = mp_detail.select("jmeno", "prijmeni", "party", "vysledek").sort(
         "party", "prijmeni", "jmeno"
     )
     mp_dicts = mp_list.to_dicts()
     for m in mp_dicts:
-        m["vote_label"] = vote_labels.get(m["vysledek"], m["vysledek"] or "?")
+        m["vote_label"] = mp_vote_label(m["vysledek"] or "")
     return mp_dicts
 
 

--- a/tests/unit/services/test_amendment_service.py
+++ b/tests/unit/services/test_amendment_service.py
@@ -94,6 +94,12 @@ class TestListAmendmentBills:
         # All bills contain "zákon" in their name
         assert result["total"] == 3
 
+    def test_search_folds_diacritics(self):
+        data = _make_data_with_amendments()
+        # ASCII query must match "zákon o testování"
+        assert list_amendment_bills(data, search="zakon")["total"] == 3
+        assert list_amendment_bills(data, search="testovani")["total"] == 3
+
     def test_pagination(self):
         data = _make_data_with_amendments()
         result = list_amendment_bills(data, per_page=2, page=1)

--- a/tests/unit/services/test_labels.py
+++ b/tests/unit/services/test_labels.py
@@ -1,0 +1,42 @@
+"""Tests for the shared vote label tokens."""
+
+from pspcz_analyzer.services.labels import mp_vote_label, vote_outcome_label
+
+
+class TestMpVoteLabel:
+    def test_known_codes(self) -> None:
+        assert mp_vote_label("A") == "YES"
+        assert mp_vote_label("B") == "NO"
+        assert mp_vote_label("C") == "ABSTAINED"
+        assert mp_vote_label("F") == "DID_NOT_VOTE"
+        assert mp_vote_label("@") == "Absent"
+        assert mp_vote_label("M") == "Excused"
+
+    def test_unknown_code_returns_raw(self) -> None:
+        assert mp_vote_label("X") == "X"
+
+    def test_empty_code_returns_placeholder(self) -> None:
+        assert mp_vote_label("") == "?"
+
+    def test_tokens_match_vote_detail_template(self) -> None:
+        """vote_detail.html compares exactly these tokens for CSS classes."""
+        expected = {
+            "A": "YES",
+            "B": "NO",
+            "C": "ABSTAINED",
+            "@": "Absent",
+            "M": "Excused",
+        }
+        for code, token in expected.items():
+            assert mp_vote_label(code) == token
+
+
+class TestVoteOutcomeLabel:
+    def test_known_outcomes(self) -> None:
+        assert vote_outcome_label("A") == "passed"
+        assert vote_outcome_label("R") == "rejected"
+        assert vote_outcome_label("Z") == "void"
+
+    def test_unknown_outcome_returns_raw(self) -> None:
+        assert vote_outcome_label("P") == "P"
+        assert vote_outcome_label("") == ""

--- a/tests/unit/services/test_law_service.py
+++ b/tests/unit/services/test_law_service.py
@@ -127,6 +127,14 @@ class TestListLaws:
         result = list_laws(data, search="ZÁKON")
         assert result["total"] == 3
 
+    def test_search_folds_diacritics(self):
+        data = _make_data_with_laws()
+        # ASCII query must match "Zákon o daních"; vice versa too
+        result = list_laws(data, search="danich")
+        assert result["total"] == 1
+        assert result["rows"][0]["ct"] == 200
+        assert list_laws(data, search="zákon o danich")["total"] == 1
+
     def test_status_filter_exact_match(self):
         data = _make_data_with_laws()
         result = list_laws(data, status_filter="vyhlášeno")

--- a/tests/unit/services/test_llm_client.py
+++ b/tests/unit/services/test_llm_client.py
@@ -1380,3 +1380,37 @@ class TestGenerateWithRetry:
         ):
             result = client.classify_topics("text about budget", "Budget Act")
         assert result == ["Rozpočet", "Zdraví"]
+
+    def test_consolidate_topics_retries_on_empty_response(self):
+        """Integration: consolidate_topics free-text path retries empty responses."""
+        client = self._make_client(structured=False)
+        responses = ["", "Dane -> Daně\nPoplatky -> Daně"]
+        with (
+            patch.object(client, "_generate", side_effect=responses),
+            patch("pspcz_analyzer.services.llm.client.LLM_EMPTY_RETRIES", 2),
+        ):
+            result = client.consolidate_topics(["Dane", "Poplatky"])
+        assert result == {"Dane": "Daně", "Poplatky": "Daně"}
+
+    def test_consolidate_topics_en_retries_on_empty_response(self):
+        """Integration: consolidate_topics_en free-text path retries empty responses."""
+        client = self._make_client(structured=False)
+        responses = ["", "Taxes -> Taxation"]
+        with (
+            patch.object(client, "_generate", side_effect=responses),
+            patch("pspcz_analyzer.services.llm.client.LLM_EMPTY_RETRIES", 2),
+        ):
+            result = client.consolidate_topics_en(["Taxes", "Taxation"])
+        assert result == {"Taxes": "Taxation", "Taxation": "Taxation"}
+
+    def test_compare_versions_bilingual_retries_empty_en(self):
+        """Integration: compare_versions_bilingual EN free-text retries empty."""
+        client = self._make_client(structured=False)
+        responses = ["", "English diff summary"]
+        with (
+            patch.object(client, "compare_versions", return_value="CS souhrn"),
+            patch.object(client, "_generate", side_effect=responses),
+            patch("pspcz_analyzer.services.llm.client.LLM_EMPTY_RETRIES", 2),
+        ):
+            result = client.compare_versions_bilingual("old", "new", 1, 2)
+        assert result == {"cs": "CS souhrn", "en": "English diff summary"}

--- a/tests/unit/services/test_party_voting.py
+++ b/tests/unit/services/test_party_voting.py
@@ -1,0 +1,61 @@
+"""Tests for the shared party majority direction helper."""
+
+import polars as pl
+
+from pspcz_analyzer.models.enums import VoteResult
+from pspcz_analyzer.services.party_voting import party_majority_direction
+
+
+def _votes(rows: list[tuple[int, str, str]]) -> pl.DataFrame:
+    """Build a (id_hlasovani, party, vysledek) frame from tuples."""
+    return pl.DataFrame(
+        {
+            "id_hlasovani": [r[0] for r in rows],
+            "party": [r[1] for r in rows],
+            "vysledek": [r[2] for r in rows],
+        }
+    )
+
+
+class TestPartyMajorityDirection:
+    def test_yes_majority(self) -> None:
+        df = _votes([(1, "ANO", "A"), (1, "ANO", "A"), (1, "ANO", "B")])
+        out = party_majority_direction(df)
+        assert out.height == 1
+        assert out.row(0, named=True)["party_direction"] == VoteResult.YES
+
+    def test_no_majority(self) -> None:
+        df = _votes([(1, "ODS", "B"), (1, "ODS", "B"), (1, "ODS", "A")])
+        out = party_majority_direction(df)
+        assert out.row(0, named=True)["party_direction"] == VoteResult.NO
+
+    def test_tie_is_dropped(self) -> None:
+        df = _votes([(1, "ANO", "A"), (1, "ANO", "B"), (2, "ODS", "A")])
+        out = party_majority_direction(df)
+        assert out.get_column("party").to_list() == ["ODS"]
+
+    def test_counts_preserved(self) -> None:
+        df = _votes([(1, "ANO", "A"), (1, "ANO", "A"), (1, "ANO", "B")])
+        row = party_majority_direction(df).row(0, named=True)
+        assert row["yes_count"] == 2
+        assert row["no_count"] == 1
+
+    def test_custom_alias_and_keys(self) -> None:
+        df = pl.DataFrame({"schuze": [5, 5, 5], "vysledek": ["B", "B", "A"]})
+        out = party_majority_direction(df, group_keys=["schuze"], direction_alias="direction")
+        assert "direction" in out.columns
+        assert out.row(0, named=True)["direction"] == VoteResult.NO
+
+    def test_direction_values_are_vote_result_codes(self) -> None:
+        """loyalty_table.html compares party_direction against 'A'/'B'."""
+        df = _votes([(1, "ANO", "A"), (1, "ODS", "B")])
+        out = party_majority_direction(df)
+        directions = dict(
+            zip(
+                out.get_column("party").to_list(),
+                out.get_column("party_direction").to_list(),
+                strict=True,
+            )
+        )
+        assert directions["ANO"] == "A"
+        assert directions["ODS"] == "B"


### PR DESCRIPTION
Part of the repo professionalization plan (PR8 — I1/I2/I4/I3-min).

## I1 — `services/labels.py`: one source of truth for vote label tokens

Three divergent implementations collapsed into table-driven `mp_vote_label()` / `vote_outcome_label()`:
- `votes_service._build_mp_breakdown` (inline dict)
- `amendment_service._vote_label` (match/case, deleted)
- `law_service._find_votes_for_ct` (match/case)

**Guardrail honored:** the plan floated gettext localization, but template grep proved the tokens are machine-facing — `vote_detail.html` compares `vote_label == "YES"/"NO"/...` to pick CSS classes and then renders its own `{{ _("vote.yes") }}`; `law_detail.html` compares `result == "passed"/"rejected"/"void"`; `loyalty_table.html` compares `party_direction == "A"/"B"`. Localizing would silently break badge styling, so the helpers return raw tokens and say so in the module docstring.

Behavior delta: votes_service's `"Passive"` for DID_NOT_VOTE unifies to `"DID_NOT_VOTE"` — both render identically (the template else branch); the amendment path's `"Unknown"` fallback becomes raw-code-or-`"?"` (nothing renders it).

## I2 — `services/party_voting.py::party_majority_direction()`

Replaces the duplicated polars majority blocks in `loyalty_service` and `amendments/coalition_service` (verified these were the only two). coalition's raw `"YES"`/`"NO"` literals become `VoteResult` enum values — internal only, since the function returns agreement *rates*. Direction values stay `"A"`/`"B"` per the loyalty template contract.

## I4 — diacritics-insensitive law/amendment search

`list_laws` and `get_amendment_bills` now route through `normalize_czech` like the votes search — `"rozpočet"` matches `"rozpocet"` in all three browsers.

## I3-min — remaining free-text LLM fallbacks get retries

The three free-text paths still bypassing `_generate_with_retry` (consolidate CS + EN, version comparison EN) now use it with an empty-rejection validator — `LLM_EMPTY_RETRIES` applies to them too; non-empty responses are byte-identical to before. Full CS/EN pair consolidation remains deferred per plan.

## Tests (+17)

- `test_labels.py` — table coverage + template-token contract
- `test_party_voting.py` — YES/NO majority, tie-drop, counts, custom alias/keys, `"A"/"B"` token contract
- diacritics search: law + amendment
- LLM: consolidation CS/EN + comparison EN retry-on-empty integration

**Gate:** 586 passed / 26 integration deselected, coverage 61.75%, pyright 0/0/0, ruff clean.