### PR TITLE
ci: gate pyright and add strict docs build check on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
 
       - name: Pyright
         run: uv run pyright
-        continue-on-error: true  # Informational — codebase not fully typed yet
 
   test-unit:
     name: Unit Tests
@@ -56,3 +55,19 @@ jobs:
           name: coverage-report
           path: .coverage
           retention-days: 7
+
+  docs:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra docs
+
+      - name: Build docs (strict)
+        run: uv run mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,4 +40,4 @@ jobs:
             mkdocs-material-
 
       - name: Build and deploy docs
-        run: uv run mkdocs gh-deploy --force
+        run: uv run mkdocs gh-deploy --force --strict


### PR DESCRIPTION
Final phase of the code-audit remediation: CI/docs hardening.

## Changes
- **Gate pyright.** Removed `continue-on-error: true` from the pyright step in `ci.yml`. Type errors now fail CI instead of being informational. Pyright currently passes with 0 errors, 0 warnings.
- **Strict docs build on PRs.** Added a `Docs Build` job to `ci.yml` that runs `mkdocs build --strict` on every pull request and push. Previously docs were only built when deploying to `main` (`docs.yml`), so broken markdown or a bad `mkdocs.yml` nav entry could merge undetected.
- **Strict deploy.** `docs.yml` now runs `mkdocs gh-deploy --force --strict`, so a broken site can never be published.

## Verified locally
- `uv run mkdocs build --strict` exits 0.
- `uv run pyright` reports 0 errors, 0 warnings.
- `uv run pytest -m "not integration" --cov -q`: 586 passed, 26 deselected, 61.75% coverage (above the 40% floor).
- Both workflow YAML files parse cleanly.

## Note for reviewers
A docs plugin prints a promotional banner during the build urging a switch to a third-party `properdocs` package. It does not affect the `--strict` gate (build exits 0), but it is worth auditing which dependency injects it.